### PR TITLE
[FEAT] 일정 목록 조회 시 시작 후 1시간 일정도 조회되도록 변경

### DIFF
--- a/src/main/java/com/youthexpedition/azit/modules/crew/adapter/out/persistence/repository/CrewScheduleRepositoryImpl.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/adapter/out/persistence/repository/CrewScheduleRepositoryImpl.java
@@ -30,7 +30,7 @@ public class CrewScheduleRepositoryImpl implements CrewScheduleRepositoryCustom 
                 .where(
                         crewScheduleEntity.crewId.eq(crewId),
                         crewScheduleEntity.status.eq(ScheduleStatus.ACTIVE), // 삭제된 일정은 제외
-                        eqDate(date),
+                        date == null ? crewScheduleEntity.meetingAt.goe(LocalDateTime.now().minusHours(1)) : eqDate(date),
                         eqRunType(runType)
                 )
                 .orderBy(crewScheduleEntity.meetingAt.asc())
@@ -68,7 +68,7 @@ public class CrewScheduleRepositoryImpl implements CrewScheduleRepositoryCustom 
                 .where(
                         crewScheduleEntity.members.any().memberId.eq(memberId),
                         crewScheduleEntity.status.eq(ScheduleStatus.ACTIVE), // 취소된 일정 제외
-                        crewScheduleEntity.meetingAt.goe(LocalDateTime.now()) // 지난 일정 제외
+                        crewScheduleEntity.meetingAt.goe(LocalDateTime.now().minusHours(1)) // 시작 이후 한시간 지난 일정(출첵 가능한 일정)부터 미래의 일정 조회
                 )
                 .orderBy(crewScheduleEntity.meetingAt.asc()) // 가장 가까운 순서대로 정렬
                 .fetch();


### PR DESCRIPTION
## 📌 관련 이슈
- closes #117

## ✨ 작업 내용
> 이번 PR에서 변경된 핵심 내용을 요약해주세요.

- 일정 목록 조회 시 시작 후 1시간 일정도 조회되도록 변경

## 🧱 아키텍처 변경 요약
> 이번 작업으로 인해 변경된 주요 흐름을 적어주세요. (없으면 생략 가능)

- 예: 신규 UseCase 추가 및 외부 API 연동 어댑터 구현

## 📸 스크린샷 (선택 사항)
> API 테스트 결과 등을 첨부해주세요.
<img width="1082" height="716" alt="image" src="https://github.com/user-attachments/assets/318ee36c-abee-4dd7-97cc-5f3fe53f6522" />


## ⚠️ 주의 사항 (선택)
- [ ] DB 스키마 변경이 있나요?
- [ ] API 명세(Swagger)가 업데이트 되었나요?
- [ ] 새로운 환경 변수(.env)가 추가 되었나요?

## ✅ 셀프 체크리스트
- [x] 브랜치 전략(develop)에 맞게 올렸나요?
- [x] 커밋 컨벤션을 준수했나요?
- [x] 불필요한 주석이나 print문은 제거했나요?
- [x] 로컬에서 테스트는 성공했나요?