### PR TITLE
[FEAT] presigned url 발급 API 및 프로필 이미지 변경 API 구현

### DIFF
--- a/src/main/java/com/youthexpedition/azit/infrastructure/common/util/ImageUrlFormatUtil.java
+++ b/src/main/java/com/youthexpedition/azit/infrastructure/common/util/ImageUrlFormatUtil.java
@@ -31,17 +31,21 @@ public class ImageUrlFormatUtil {
     /**
      * 이미지 경로에서 S3 Key 추출
      * CloudFront URL: https://azitcrew.com/profile/123/2026-04-07_550e8400.jpg → profile/123/2026-04-07_550e8400.jpg
-     * 상대 경로: /profile/123/2026-04-07_550e8400.jpg → profile/123/2026-04-07_550e8400.jpg
+     * 상대 경로:      /profile/123/2026-04-07_550e8400.jpg                     → profile/123/2026-04-07_550e8400.jpg
      */
     public String extractS3Key(String imageUrl) {
         if (imageUrl == null || imageUrl.isBlank()) {
             return null;
         }
-        if (imageUrl.startsWith(cloudFrontDomain)) {
-            return imageUrl.substring(cloudFrontDomain.length() + 1); // +1: 선행 '/' 제거
+        // trailing slash 정규화 (설정값 끝에 '/' 포함 여부와 무관하게 동작)
+        String normalizedDomain = cloudFrontDomain.endsWith("/")
+                ? cloudFrontDomain.substring(0, cloudFrontDomain.length() - 1)
+                : cloudFrontDomain;
+        if (imageUrl.startsWith(normalizedDomain + "/")) {
+            return imageUrl.substring(normalizedDomain.length() + 1);
         }
         if (imageUrl.startsWith("/")) {
-            return imageUrl.substring(1); // 선행 '/' 제거
+            return imageUrl.substring(1);
         }
         return null;
     }

--- a/src/main/java/com/youthexpedition/azit/infrastructure/common/util/ImageUrlFormatUtil.java
+++ b/src/main/java/com/youthexpedition/azit/infrastructure/common/util/ImageUrlFormatUtil.java
@@ -27,4 +27,22 @@ public class ImageUrlFormatUtil {
 
         return cloudFrontDomain + imagePath;
     }
+
+    /**
+     * 이미지 경로에서 S3 Key 추출
+     * CloudFront URL: https://azitcrew.com/profile/123/2026-04-07_550e8400.jpg → profile/123/2026-04-07_550e8400.jpg
+     * 상대 경로: /profile/123/2026-04-07_550e8400.jpg → profile/123/2026-04-07_550e8400.jpg
+     */
+    public String extractS3Key(String imageUrl) {
+        if (imageUrl == null || imageUrl.isBlank()) {
+            return null;
+        }
+        if (imageUrl.startsWith(cloudFrontDomain)) {
+            return imageUrl.substring(cloudFrontDomain.length() + 1); // +1: 선행 '/' 제거
+        }
+        if (imageUrl.startsWith("/")) {
+            return imageUrl.substring(1); // 선행 '/' 제거
+        }
+        return null;
+    }
 }

--- a/src/main/java/com/youthexpedition/azit/infrastructure/config/S3Config.java
+++ b/src/main/java/com/youthexpedition/azit/infrastructure/config/S3Config.java
@@ -1,0 +1,31 @@
+package com.youthexpedition.azit.infrastructure.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+
+@Configuration
+public class S3Config {
+
+    @Value("${spring.cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${spring.cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${spring.cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public S3Presigner s3Presigner() {
+        AwsBasicCredentials credentials = AwsBasicCredentials.create(accessKey, secretKey);
+        return S3Presigner.builder()
+                .region(Region.of(region))
+                .credentialsProvider(StaticCredentialsProvider.create(credentials))
+                .build();
+    }
+}

--- a/src/main/java/com/youthexpedition/azit/modules/image/adapter/in/web/ImageController.java
+++ b/src/main/java/com/youthexpedition/azit/modules/image/adapter/in/web/ImageController.java
@@ -1,0 +1,29 @@
+package com.youthexpedition.azit.modules.image.adapter.in.web;
+
+import com.youthexpedition.azit.infrastructure.common.annotation.CurrentMemberId;
+import com.youthexpedition.azit.infrastructure.common.response.CommonResponse;
+import com.youthexpedition.azit.infrastructure.common.response.code.CommonSuccessCode;
+import com.youthexpedition.azit.modules.image.adapter.in.web.docs.ImageControllerDocs;
+import com.youthexpedition.azit.modules.image.adapter.in.web.dto.PresignedUrlRequest;
+import com.youthexpedition.azit.modules.image.application.port.in.ImageUseCase;
+import com.youthexpedition.azit.modules.image.application.port.in.dto.PresignedUrlResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/images")
+@RequiredArgsConstructor
+public class ImageController implements ImageControllerDocs {
+
+    private final ImageUseCase imageUseCase;
+
+    @PostMapping("/presigned-url")
+    public CommonResponse<PresignedUrlResponse> generatePresignedUrl(@CurrentMemberId Long memberId, @Valid @RequestBody PresignedUrlRequest request) {
+        PresignedUrlResponse response = imageUseCase.generatePresignedUrl(request.toCommand(memberId));
+        return CommonResponse.of(CommonSuccessCode.SUCCESS, response);
+    }
+}

--- a/src/main/java/com/youthexpedition/azit/modules/image/adapter/in/web/docs/ImageControllerDocs.java
+++ b/src/main/java/com/youthexpedition/azit/modules/image/adapter/in/web/docs/ImageControllerDocs.java
@@ -1,0 +1,43 @@
+package com.youthexpedition.azit.modules.image.adapter.in.web.docs;
+
+import com.youthexpedition.azit.infrastructure.common.annotation.CurrentMemberId;
+import com.youthexpedition.azit.infrastructure.common.response.CommonResponse;
+import com.youthexpedition.azit.infrastructure.config.swagger.ApiErrorCodeExamples;
+import com.youthexpedition.azit.modules.image.adapter.in.web.dto.PresignedUrlRequest;
+import com.youthexpedition.azit.modules.image.application.port.in.dto.PresignedUrlResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "Image", description = "이미지 업로드 API")
+public interface ImageControllerDocs {
+
+    @Operation(
+            summary = "이미지 업로드용 Presigned URL 발급",
+            description = """
+                    S3에 이미지를 직접 업로드하기 위한 Presigned URL을 발급합니다. <br><br>
+
+                    **[전체 플로우]** <br>
+                    1. 해당 API를 호출하여 presignedUrl과 imageUrl을 발급받습니다. <br>
+                    2. 클라이언트에서 presignedUrl로 **PUT 요청**을 보내 이미지를 업로드합니다. <br>
+                    3. 업로드 완료 후 imageUrl으로 프로필 수정 / 크루 이미지 수정 등 관련 API를 호출합니다. <br><br>
+
+                    **[업로드 타입]** <br>
+                    * MEMBER_PROFILE : 프로필 이미지 <br><br>
+
+                    **[제약 사항]** <br>
+                    * 허용 확장자: jpg, jpeg, png, webp <br>
+                    * Presigned URL 유효 시간: 5분
+                    """
+    )
+    @ApiErrorCodeExamples({
+            "UNSUPPORTED_FILE_EXTENSION", "INVALID_FILE_NAME",
+            "UNAUTHORIZED", "EXPIRED_TOKEN", "INVALID_TOKEN", "TOKEN_REUSE_DETECTED", "BLACKLISTED_TOKEN"
+    })
+    CommonResponse<PresignedUrlResponse> generatePresignedUrl(
+            @Parameter(hidden = true) @CurrentMemberId Long memberId,
+            @Valid @RequestBody PresignedUrlRequest request
+    );
+}

--- a/src/main/java/com/youthexpedition/azit/modules/image/adapter/in/web/docs/ImageControllerDocs.java
+++ b/src/main/java/com/youthexpedition/azit/modules/image/adapter/in/web/docs/ImageControllerDocs.java
@@ -28,8 +28,9 @@ public interface ImageControllerDocs {
                     * MEMBER_PROFILE : 프로필 이미지 <br><br>
 
                     **[제약 사항]** <br>
-                    * 허용 확장자: jpg, jpeg, png, webp <br>
-                    * Presigned URL 유효 시간: 5분
+                    * 허용 확장자: jpg, jpeg, png, webp (그 외: UNSUPPORTED_FILE_EXTENSION) <br>
+                    * Presigned URL 유효 시간: 5분 <br>
+                    * 확장자 파싱이 불가능한 올바르지 않은 파일명일 경우 INVALID_FILE_NAME 에러가 발생합니다.
                     """
     )
     @ApiErrorCodeExamples({

--- a/src/main/java/com/youthexpedition/azit/modules/image/adapter/in/web/dto/PresignedUrlRequest.java
+++ b/src/main/java/com/youthexpedition/azit/modules/image/adapter/in/web/dto/PresignedUrlRequest.java
@@ -1,0 +1,22 @@
+package com.youthexpedition.azit.modules.image.adapter.in.web.dto;
+
+import com.youthexpedition.azit.modules.image.application.port.in.command.GeneratePresignedUrlCommand;
+import com.youthexpedition.azit.modules.image.domain.model.enums.ImageUploadType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record PresignedUrlRequest(
+        @Schema(description = "이미지 업로드 타입", requiredMode = Schema.RequiredMode.REQUIRED, allowableValues = {"MEMBER_PROFILE"})
+        @NotNull(message = "이미지 업로드 타입은 필수입니다.")
+        ImageUploadType type,
+
+        @Schema(description = "업로드할 파일명 (확장자 포함)", requiredMode = Schema.RequiredMode.REQUIRED,
+                example = "photo.jpg")
+        @NotBlank(message = "파일명은 필수입니다.")
+        String fileName
+) {
+    public GeneratePresignedUrlCommand toCommand(Long memberId) {
+        return GeneratePresignedUrlCommand.of(type, fileName, memberId);
+    }
+}

--- a/src/main/java/com/youthexpedition/azit/modules/image/adapter/out/storage/S3ImageStorageAdapter.java
+++ b/src/main/java/com/youthexpedition/azit/modules/image/adapter/out/storage/S3ImageStorageAdapter.java
@@ -1,0 +1,80 @@
+package com.youthexpedition.azit.modules.image.adapter.out.storage;
+
+import com.youthexpedition.azit.modules.image.application.port.out.ImageStoragePort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.CopyObjectRequest;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
+
+import java.time.Duration;
+
+@Component
+@RequiredArgsConstructor
+public class S3ImageStorageAdapter implements ImageStoragePort {
+
+    private final S3Client s3Client;
+    private final S3Presigner s3Presigner;
+
+    @Value("${spring.cloud.aws.s3.bucket}")
+    private String bucket;
+
+    @Override
+    public String generatePresignedUrl(String s3Key, String contentType, Duration expiry) {
+        PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                .bucket(bucket)
+                .key(s3Key)
+                .contentType(contentType)
+                .build();
+
+        PutObjectPresignRequest presignRequest = PutObjectPresignRequest.builder()
+                .signatureDuration(expiry)
+                .putObjectRequest(putObjectRequest)
+                .build();
+
+        PresignedPutObjectRequest presignedRequest = s3Presigner.presignPutObject(presignRequest);
+        return presignedRequest.url().toString();
+    }
+
+    @Override
+    public boolean exists(String s3Key) {
+        try {
+            s3Client.headObject(HeadObjectRequest.builder()
+                    .bucket(bucket)
+                    .key(s3Key)
+                    .build());
+            return true;
+        } catch (NoSuchKeyException e) {
+            return false;
+        }
+    }
+
+    @Override
+    public void delete(String s3Key) {
+        s3Client.deleteObject(DeleteObjectRequest.builder()
+                .bucket(bucket)
+                .key(s3Key)
+                .build());
+    }
+
+    @Override
+    public void move(String sourceKey, String destinationKey) {
+        s3Client.copyObject(CopyObjectRequest.builder()
+                .sourceBucket(bucket)
+                .sourceKey(sourceKey)
+                .destinationBucket(bucket)
+                .destinationKey(destinationKey)
+                .build());
+        s3Client.deleteObject(DeleteObjectRequest.builder()
+                .bucket(bucket)
+                .key(sourceKey)
+                .build());
+    }
+}

--- a/src/main/java/com/youthexpedition/azit/modules/image/application/port/in/ImageUseCase.java
+++ b/src/main/java/com/youthexpedition/azit/modules/image/application/port/in/ImageUseCase.java
@@ -1,0 +1,8 @@
+package com.youthexpedition.azit.modules.image.application.port.in;
+
+import com.youthexpedition.azit.modules.image.application.port.in.command.GeneratePresignedUrlCommand;
+import com.youthexpedition.azit.modules.image.application.port.in.dto.PresignedUrlResponse;
+
+public interface ImageUseCase {
+    PresignedUrlResponse generatePresignedUrl(GeneratePresignedUrlCommand command);
+}

--- a/src/main/java/com/youthexpedition/azit/modules/image/application/port/in/command/GeneratePresignedUrlCommand.java
+++ b/src/main/java/com/youthexpedition/azit/modules/image/application/port/in/command/GeneratePresignedUrlCommand.java
@@ -1,0 +1,13 @@
+package com.youthexpedition.azit.modules.image.application.port.in.command;
+
+import com.youthexpedition.azit.modules.image.domain.model.enums.ImageUploadType;
+
+public record GeneratePresignedUrlCommand(
+        ImageUploadType type,
+        String fileName,
+        Long memberId
+) {
+    public static GeneratePresignedUrlCommand of(ImageUploadType type, String fileName, Long memberId) {
+        return new GeneratePresignedUrlCommand(type, fileName, memberId);
+    }
+}

--- a/src/main/java/com/youthexpedition/azit/modules/image/application/port/in/dto/PresignedUrlResponse.java
+++ b/src/main/java/com/youthexpedition/azit/modules/image/application/port/in/dto/PresignedUrlResponse.java
@@ -1,0 +1,10 @@
+package com.youthexpedition.azit.modules.image.application.port.in.dto;
+
+public record PresignedUrlResponse(
+        String presignedUrl,
+        String imageUrl
+) {
+    public static PresignedUrlResponse of(String presignedUrl, String imageUrl) {
+        return new PresignedUrlResponse(presignedUrl, imageUrl);
+    }
+}

--- a/src/main/java/com/youthexpedition/azit/modules/image/application/port/out/ImageStoragePort.java
+++ b/src/main/java/com/youthexpedition/azit/modules/image/application/port/out/ImageStoragePort.java
@@ -1,0 +1,10 @@
+package com.youthexpedition.azit.modules.image.application.port.out;
+
+import java.time.Duration;
+
+public interface ImageStoragePort {
+    String generatePresignedUrl(String s3Key, String contentType, Duration expiry);
+    boolean exists(String s3Key);
+    void delete(String s3Key);
+    void move(String sourceKey, String destinationKey);
+}

--- a/src/main/java/com/youthexpedition/azit/modules/image/application/service/ImageService.java
+++ b/src/main/java/com/youthexpedition/azit/modules/image/application/service/ImageService.java
@@ -1,0 +1,67 @@
+package com.youthexpedition.azit.modules.image.application.service;
+
+import com.youthexpedition.azit.infrastructure.common.util.ImageUrlFormatUtil;
+import com.youthexpedition.azit.infrastructure.exception.BusinessException;
+import com.youthexpedition.azit.modules.image.application.port.in.ImageUseCase;
+import com.youthexpedition.azit.modules.image.application.port.in.command.GeneratePresignedUrlCommand;
+import com.youthexpedition.azit.modules.image.application.port.in.dto.PresignedUrlResponse;
+import com.youthexpedition.azit.modules.image.application.port.out.ImageStoragePort;
+import com.youthexpedition.azit.modules.image.domain.model.enums.ImageErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.time.LocalDate;
+import java.util.Set;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class ImageService implements ImageUseCase {
+
+    private final ImageStoragePort imageStoragePort;
+    private final ImageUrlFormatUtil imageUrlFormatUtil;
+
+    private static final Set<String> ALLOWED_EXTENSIONS = Set.of("jpg", "jpeg", "png", "webp");
+    private static final Duration PRESIGNED_URL_EXPIRY = Duration.ofMinutes(5);
+
+    @Override
+    public PresignedUrlResponse generatePresignedUrl(GeneratePresignedUrlCommand command) {
+        String extension = extractExtension(command.fileName());
+        validateExtension(extension);
+
+        String s3Key = buildS3Key(command, extension);
+        String contentType = resolveContentType(extension);
+
+        String presignedUrl = imageStoragePort.generatePresignedUrl(s3Key, contentType, PRESIGNED_URL_EXPIRY);
+        String imageUrl = imageUrlFormatUtil.buildFullImageUrl("/" + s3Key);
+
+        return PresignedUrlResponse.of(presignedUrl, imageUrl);
+    }
+
+    private String buildS3Key(GeneratePresignedUrlCommand command, String extension) {
+        String fileName = LocalDate.now() + "_" + UUID.randomUUID();
+        return "temp/" + command.type().buildPath(command.memberId()) + "/" + fileName + "." + extension;
+    }
+
+    private String extractExtension(String fileName) {
+        if (fileName == null || !fileName.contains(".")) {
+            throw new BusinessException(ImageErrorCode.INVALID_FILE_NAME);
+        }
+        String extension = fileName.substring(fileName.lastIndexOf('.') + 1);
+        if (extension.isBlank()) {
+            throw new BusinessException(ImageErrorCode.INVALID_FILE_NAME);
+        }
+        return extension.toLowerCase();
+    }
+
+    private void validateExtension(String extension) {
+        if (!ALLOWED_EXTENSIONS.contains(extension)) {
+            throw new BusinessException(ImageErrorCode.UNSUPPORTED_FILE_EXTENSION);
+        }
+    }
+
+    private String resolveContentType(String extension) {
+        return "image/" + (extension.equals("jpg") ? "jpeg" : extension);
+    }
+}

--- a/src/main/java/com/youthexpedition/azit/modules/image/application/service/ImageService.java
+++ b/src/main/java/com/youthexpedition/azit/modules/image/application/service/ImageService.java
@@ -7,6 +7,7 @@ import com.youthexpedition.azit.modules.image.application.port.in.command.Genera
 import com.youthexpedition.azit.modules.image.application.port.in.dto.PresignedUrlResponse;
 import com.youthexpedition.azit.modules.image.application.port.out.ImageStoragePort;
 import com.youthexpedition.azit.modules.image.domain.model.enums.ImageErrorCode;
+import com.youthexpedition.azit.modules.image.domain.model.enums.ImageUploadType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -41,7 +42,7 @@ public class ImageService implements ImageUseCase {
 
     private String buildS3Key(GeneratePresignedUrlCommand command, String extension) {
         String fileName = LocalDate.now() + "_" + UUID.randomUUID();
-        return "temp/" + command.type().buildPath(command.memberId()) + "/" + fileName + "." + extension;
+        return ImageUploadType.TEMP_PREFIX + command.type().buildPath(command.memberId()) + "/" + fileName + "." + extension;
     }
 
     private String extractExtension(String fileName) {

--- a/src/main/java/com/youthexpedition/azit/modules/image/domain/model/enums/ImageErrorCode.java
+++ b/src/main/java/com/youthexpedition/azit/modules/image/domain/model/enums/ImageErrorCode.java
@@ -1,0 +1,20 @@
+package com.youthexpedition.azit.modules.image.domain.model.enums;
+
+import com.youthexpedition.azit.infrastructure.common.response.code.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ImageErrorCode implements BaseErrorCode {
+    UNSUPPORTED_FILE_EXTENSION("UNSUPPORTED_FILE_EXTENSION", "지원하지 않는 파일 형식입니다. (jpg, jpeg, png, webp만 허용)", HttpStatus.BAD_REQUEST),
+    INVALID_FILE_NAME("INVALID_FILE_NAME", "올바르지 않은 파일명입니다.", HttpStatus.BAD_REQUEST),
+    IMAGE_NOT_UPLOADED("IMAGE_NOT_UPLOADED", "이미지가 업로드되지 않았습니다. 먼저 이미지를 업로드해 주세요.", HttpStatus.BAD_REQUEST),
+    IMAGE_OWNERSHIP_MISMATCH("IMAGE_OWNERSHIP_MISMATCH", "본인이 업로드한 이미지만 사용할 수 있습니다.", HttpStatus.FORBIDDEN),
+    ;
+
+    private final String code;
+    private final String message;
+    private final HttpStatus status;
+}

--- a/src/main/java/com/youthexpedition/azit/modules/image/domain/model/enums/ImageUploadType.java
+++ b/src/main/java/com/youthexpedition/azit/modules/image/domain/model/enums/ImageUploadType.java
@@ -9,9 +9,24 @@ public enum ImageUploadType {
     STORE_REVIEW("review"),
     ;
 
+    public static final String TEMP_PREFIX = "temp/";
+
     private final String directory;
 
     public String buildPath(Long memberId) {
         return directory + "/" + memberId;
+    }
+
+    /**
+     * temp S3 Key에서 memberId 추출
+     * 경로 구조: temp/{directory}/{memberId}/{fileName}
+     */
+    public static Long extractMemberIdFromTempKey(String tempS3Key) {
+        try {
+            String[] parts = tempS3Key.split("/");
+            return Long.parseLong(parts[2]);
+        } catch (NumberFormatException | ArrayIndexOutOfBoundsException e) {
+            return null;
+        }
     }
 }

--- a/src/main/java/com/youthexpedition/azit/modules/image/domain/model/enums/ImageUploadType.java
+++ b/src/main/java/com/youthexpedition/azit/modules/image/domain/model/enums/ImageUploadType.java
@@ -1,0 +1,17 @@
+package com.youthexpedition.azit.modules.image.domain.model.enums;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum ImageUploadType {
+    MEMBER_PROFILE("profile"),
+    CREW_IMAGE("crew"),
+    STORE_REVIEW("review"),
+    ;
+
+    private final String directory;
+
+    public String buildPath(Long memberId) {
+        return directory + "/" + memberId;
+    }
+}

--- a/src/main/java/com/youthexpedition/azit/modules/member/adapter/in/web/MemberController.java
+++ b/src/main/java/com/youthexpedition/azit/modules/member/adapter/in/web/MemberController.java
@@ -12,6 +12,7 @@ import com.youthexpedition.azit.modules.crew.application.port.in.dto.CrewSchedul
 import com.youthexpedition.azit.modules.member.adapter.in.web.docs.MemberControllerDocs;
 import com.youthexpedition.azit.modules.member.adapter.in.web.dto.AgreeToTermsRequest;
 import com.youthexpedition.azit.modules.member.adapter.in.web.dto.UpdateNicknameRequest;
+import com.youthexpedition.azit.modules.member.adapter.in.web.dto.UpdateProfileImageRequest;
 import com.youthexpedition.azit.modules.member.application.port.in.MemberUseCase;
 import com.youthexpedition.azit.modules.member.application.port.in.dto.MyAttendanceLogResponse;
 import com.youthexpedition.azit.modules.member.application.port.in.dto.MyAttendanceMonthlyListResponse;
@@ -103,6 +104,13 @@ public class MemberController implements MemberControllerDocs {
     @PatchMapping("/me/nickname")
     public CommonResponse<Void> updateNickname(@CurrentMemberId Long memberId, @Valid @RequestBody UpdateNicknameRequest request) {
         memberUseCase.updateNickname(memberId, request.toCommand());
+
+        return CommonResponse.of(CommonSuccessCode.SUCCESS);
+    }
+
+    @PatchMapping("/me/profile-image")
+    public CommonResponse<Void> updateProfileImage(@CurrentMemberId Long memberId, @Valid @RequestBody UpdateProfileImageRequest request) {
+        memberUseCase.updateProfileImage(memberId, request.toCommand());
 
         return CommonResponse.of(CommonSuccessCode.SUCCESS);
     }

--- a/src/main/java/com/youthexpedition/azit/modules/member/adapter/in/web/docs/MemberControllerDocs.java
+++ b/src/main/java/com/youthexpedition/azit/modules/member/adapter/in/web/docs/MemberControllerDocs.java
@@ -9,6 +9,7 @@ import com.youthexpedition.azit.modules.crew.application.port.in.dto.CheckInStat
 import com.youthexpedition.azit.modules.crew.application.port.in.dto.CrewScheduleListResponse;
 import com.youthexpedition.azit.modules.member.adapter.in.web.dto.AgreeToTermsRequest;
 import com.youthexpedition.azit.modules.member.adapter.in.web.dto.UpdateNicknameRequest;
+import com.youthexpedition.azit.modules.member.adapter.in.web.dto.UpdateProfileImageRequest;
 import com.youthexpedition.azit.modules.member.application.port.in.dto.MyAttendanceLogResponse;
 import com.youthexpedition.azit.modules.member.application.port.in.dto.MyAttendanceMonthlyListResponse;
 import com.youthexpedition.azit.modules.member.application.port.in.dto.MyInfoResponse;
@@ -212,7 +213,7 @@ public interface MemberControllerDocs {
             로그인한 사용자의 닉네임을 수정합니다. <br><br>
 
             **[제약 사항]** <br>
-            * 닉네임은 최대 10자까지 입력 가능합니다. (INVALID_NICKNAME) <br>
+            * 닉네임은 최대 10자까지 입력 가능합니다. <br>
             * 특수문자는 사용할 수 없으며, 한글/영문/숫자만 허용됩니다.
             """
     )
@@ -221,5 +222,22 @@ public interface MemberControllerDocs {
     })
     CommonResponse<Void> updateNickname(@Parameter(hidden = true) @CurrentMemberId Long memberId, @Valid @RequestBody UpdateNicknameRequest request);
 
+    @Operation(
+            summary = "프로필 이미지 수정",
+            description = """
+                    로그인한 사용자의 프로필 이미지를 수정합니다. <br><br>
 
+                    **[사전 조건]** <br>
+                    * POST /api/v1/images/presigned-url API로 Presigned URL을 발급받은 뒤, S3에 이미지를 **실제로 업로드한 후** 호출해야 합니다. <br><br>
+
+                    **[제약 사항]** <br>
+                    * 업로드되지 않은 이미지 URL을 전달하면 IMAGE_NOT_UPLOADED 오류가 반환됩니다. <br>
+                    * 본인이 업로드한 이미지 URL만 사용할 수 있습니다. (IMAGE_OWNERSHIP_MISMATCH)
+                    """
+    )
+    @ApiErrorCodeExamples({
+            "MEMBER_NOT_FOUND", "IMAGE_NOT_UPLOADED", "IMAGE_OWNERSHIP_MISMATCH",
+            "UNAUTHORIZED", "EXPIRED_TOKEN", "INVALID_TOKEN", "TOKEN_REUSE_DETECTED", "BLACKLISTED_TOKEN"
+    })
+    CommonResponse<Void> updateProfileImage(@Parameter(hidden = true) @CurrentMemberId Long memberId, @Valid @RequestBody UpdateProfileImageRequest request);
 }

--- a/src/main/java/com/youthexpedition/azit/modules/member/adapter/in/web/dto/UpdateProfileImageRequest.java
+++ b/src/main/java/com/youthexpedition/azit/modules/member/adapter/in/web/dto/UpdateProfileImageRequest.java
@@ -1,0 +1,16 @@
+package com.youthexpedition.azit.modules.member.adapter.in.web.dto;
+
+import com.youthexpedition.azit.modules.member.application.port.in.command.UpdateProfileImageCommand;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+public record UpdateProfileImageRequest(
+        @Schema(description = "업로드 완료된 이미지의 CloudFront URL", requiredMode = Schema.RequiredMode.REQUIRED,
+                example = "https://azitcrew.com/profile/123/2026-04-07_550e8400.jpg")
+        @NotBlank(message = "이미지 URL은 필수입니다.")
+        String imageUrl
+) {
+    public UpdateProfileImageCommand toCommand() {
+        return UpdateProfileImageCommand.of(imageUrl);
+    }
+}

--- a/src/main/java/com/youthexpedition/azit/modules/member/application/port/in/MemberUseCase.java
+++ b/src/main/java/com/youthexpedition/azit/modules/member/application/port/in/MemberUseCase.java
@@ -2,6 +2,7 @@ package com.youthexpedition.azit.modules.member.application.port.in;
 
 import com.youthexpedition.azit.modules.member.application.port.in.command.AgreeToTermsCommand;
 import com.youthexpedition.azit.modules.member.application.port.in.command.UpdateNicknameCommand;
+import com.youthexpedition.azit.modules.member.application.port.in.command.UpdateProfileImageCommand;
 import com.youthexpedition.azit.modules.member.application.port.in.dto.MyInfoResponse;
 import com.youthexpedition.azit.modules.member.domain.model.enums.SocialProvider;
 
@@ -13,4 +14,5 @@ public interface MemberUseCase {
     void confirmMemberStatus(Long memberId);
     MyInfoResponse getMyInfo(Long memberId);
     void updateNickname(Long memberId, UpdateNicknameCommand command);
+    void updateProfileImage(Long memberId, UpdateProfileImageCommand command);
 }

--- a/src/main/java/com/youthexpedition/azit/modules/member/application/port/in/command/UpdateProfileImageCommand.java
+++ b/src/main/java/com/youthexpedition/azit/modules/member/application/port/in/command/UpdateProfileImageCommand.java
@@ -1,0 +1,7 @@
+package com.youthexpedition.azit.modules.member.application.port.in.command;
+
+public record UpdateProfileImageCommand(String imageUrl) {
+    public static UpdateProfileImageCommand of(String imageUrl) {
+        return new UpdateProfileImageCommand(imageUrl);
+    }
+}

--- a/src/main/java/com/youthexpedition/azit/modules/member/application/service/MemberService.java
+++ b/src/main/java/com/youthexpedition/azit/modules/member/application/service/MemberService.java
@@ -17,6 +17,7 @@ import com.youthexpedition.azit.modules.member.application.port.in.MemberUseCase
 import com.youthexpedition.azit.infrastructure.common.util.ImageUrlFormatUtil;
 import com.youthexpedition.azit.modules.image.application.port.out.ImageStoragePort;
 import com.youthexpedition.azit.modules.image.domain.model.enums.ImageErrorCode;
+import com.youthexpedition.azit.modules.image.domain.model.enums.ImageUploadType;
 import com.youthexpedition.azit.modules.member.application.port.in.command.AgreeToTermsCommand;
 import com.youthexpedition.azit.modules.member.application.port.in.command.UpdateNicknameCommand;
 import com.youthexpedition.azit.modules.member.application.port.in.command.UpdateProfileImageCommand;
@@ -52,6 +53,7 @@ public class MemberService implements MemberUseCase {
     private final ImageUrlFormatUtil imageUrlFormatUtil;
 
     private static final String BLACKLIST_REASON_WITHDRAWN = "withdrawn";
+    private static final String DEFAULT_S3_PREFIX = "default/";
 
     @Override
     public void agreeToTerms(Long memberId, AgreeToTermsCommand command) {
@@ -219,15 +221,12 @@ public class MemberService implements MemberUseCase {
     }
 
     private void validateImageOwnership(String tempS3Key, Long memberId) {
-        // tempS3Key 구조: temp/{directory}/{memberId}/{fileName}
-        try {
-            String[] parts = tempS3Key.split("/");
-            Long imageOwnerMemberId = Long.parseLong(parts[2]);
-            if (!imageOwnerMemberId.equals(memberId)) {
-                throw new BusinessException(ImageErrorCode.IMAGE_OWNERSHIP_MISMATCH);
-            }
-        } catch (NumberFormatException | ArrayIndexOutOfBoundsException e) {
+        Long imageOwnerMemberId = ImageUploadType.extractMemberIdFromTempKey(tempS3Key);
+        if (imageOwnerMemberId == null) {
             throw new BusinessException(ImageErrorCode.IMAGE_NOT_UPLOADED);
+        }
+        if (!imageOwnerMemberId.equals(memberId)) {
+            throw new BusinessException(ImageErrorCode.IMAGE_OWNERSHIP_MISMATCH);
         }
     }
 
@@ -242,7 +241,7 @@ public class MemberService implements MemberUseCase {
     public void updateProfileImage(Long memberId, UpdateProfileImageCommand command) {
         // temp 경로 파일 존재 여부 검증
         String tempS3Key = imageUrlFormatUtil.extractS3Key(command.imageUrl());
-        if (tempS3Key == null || !tempS3Key.startsWith("temp/") || !imageStoragePort.exists(tempS3Key)) {
+        if (tempS3Key == null || !tempS3Key.startsWith(ImageUploadType.TEMP_PREFIX) || !imageStoragePort.exists(tempS3Key)) {
             throw new BusinessException(ImageErrorCode.IMAGE_NOT_UPLOADED);
         }
 
@@ -253,12 +252,12 @@ public class MemberService implements MemberUseCase {
 
         // 기존 업로드 이미지 삭제 (기본 이미지, 외부 URL 제외)
         String oldS3Key = imageUrlFormatUtil.extractS3Key(member.getProfileImageUrl());
-        if (oldS3Key != null && !oldS3Key.startsWith("default/")) {
+        if (oldS3Key != null && !oldS3Key.startsWith(DEFAULT_S3_PREFIX)) {
             imageStoragePort.delete(oldS3Key);
         }
 
         // temp → 실제 경로로 이동
-        String finalS3Key = tempS3Key.substring("temp/".length());
+        String finalS3Key = tempS3Key.substring(ImageUploadType.TEMP_PREFIX.length());
         imageStoragePort.move(tempS3Key, finalS3Key);
 
         // 상대 경로 저장

--- a/src/main/java/com/youthexpedition/azit/modules/member/application/service/MemberService.java
+++ b/src/main/java/com/youthexpedition/azit/modules/member/application/service/MemberService.java
@@ -14,8 +14,12 @@ import com.youthexpedition.azit.modules.crew.domain.model.enums.CrewErrorCode;
 import com.youthexpedition.azit.modules.crew.domain.model.enums.CrewMemberRole;
 import com.youthexpedition.azit.modules.crew.domain.model.enums.CrewMemberStatus;
 import com.youthexpedition.azit.modules.member.application.port.in.MemberUseCase;
+import com.youthexpedition.azit.infrastructure.common.util.ImageUrlFormatUtil;
+import com.youthexpedition.azit.modules.image.application.port.out.ImageStoragePort;
+import com.youthexpedition.azit.modules.image.domain.model.enums.ImageErrorCode;
 import com.youthexpedition.azit.modules.member.application.port.in.command.AgreeToTermsCommand;
 import com.youthexpedition.azit.modules.member.application.port.in.command.UpdateNicknameCommand;
+import com.youthexpedition.azit.modules.member.application.port.in.command.UpdateProfileImageCommand;
 import com.youthexpedition.azit.modules.member.application.port.in.dto.MyInfoResponse;
 import com.youthexpedition.azit.modules.member.application.port.out.LoadMemberPort;
 import com.youthexpedition.azit.modules.member.application.port.out.SaveMemberPort;
@@ -44,6 +48,8 @@ public class MemberService implements MemberUseCase {
     private final SocialAuthPort socialAuthPort;
     private final TokenPort tokenPort;
     private final MemberResponseMapper memberResponseMapper;
+    private final ImageStoragePort imageStoragePort;
+    private final ImageUrlFormatUtil imageUrlFormatUtil;
 
     private static final String BLACKLIST_REASON_WITHDRAWN = "withdrawn";
 
@@ -212,10 +218,51 @@ public class MemberService implements MemberUseCase {
         }
     }
 
+    private void validateImageOwnership(String tempS3Key, Long memberId) {
+        // tempS3Key 구조: temp/{directory}/{memberId}/{fileName}
+        try {
+            String[] parts = tempS3Key.split("/");
+            Long imageOwnerMemberId = Long.parseLong(parts[2]);
+            if (!imageOwnerMemberId.equals(memberId)) {
+                throw new BusinessException(ImageErrorCode.IMAGE_OWNERSHIP_MISMATCH);
+            }
+        } catch (NumberFormatException | ArrayIndexOutOfBoundsException e) {
+            throw new BusinessException(ImageErrorCode.IMAGE_NOT_UPLOADED);
+        }
+    }
+
     @Override
     public void updateNickname(Long memberId, UpdateNicknameCommand command) {
         Member member = getMember(memberId);
         member.updateNickname(command.nickname());
+        saveMemberPort.save(member);
+    }
+
+    @Override
+    public void updateProfileImage(Long memberId, UpdateProfileImageCommand command) {
+        // temp 경로 파일 존재 여부 검증
+        String tempS3Key = imageUrlFormatUtil.extractS3Key(command.imageUrl());
+        if (tempS3Key == null || !tempS3Key.startsWith("temp/") || !imageStoragePort.exists(tempS3Key)) {
+            throw new BusinessException(ImageErrorCode.IMAGE_NOT_UPLOADED);
+        }
+
+        // 본인이 업로드한 이미지인지 검증
+        validateImageOwnership(tempS3Key, memberId);
+
+        Member member = getMember(memberId);
+
+        // 기존 업로드 이미지 삭제 (기본 이미지, 외부 URL 제외)
+        String oldS3Key = imageUrlFormatUtil.extractS3Key(member.getProfileImageUrl());
+        if (oldS3Key != null && !oldS3Key.startsWith("default/")) {
+            imageStoragePort.delete(oldS3Key);
+        }
+
+        // temp → 실제 경로로 이동
+        String finalS3Key = tempS3Key.substring("temp/".length());
+        imageStoragePort.move(tempS3Key, finalS3Key);
+
+        // 상대 경로 저장
+        member.updateProfileImageUrl("/" + finalS3Key);
         saveMemberPort.save(member);
     }
 }

--- a/src/main/java/com/youthexpedition/azit/modules/member/domain/model/Member.java
+++ b/src/main/java/com/youthexpedition/azit/modules/member/domain/model/Member.java
@@ -168,6 +168,11 @@ public class Member {
         this.nickname = nickname;
     }
 
+    // 프로필 이미지 수정
+    public void updateProfileImageUrl(String profileImageUrl) {
+        this.profileImageUrl = profileImageUrl;
+    }
+
     public void updateAttendanceCount() {
         this.totalAttendanceCount++;
     }


### PR DESCRIPTION
## 📌 관련 이슈
- #150

## ✨ 작업 내용
> 이번 PR에서 변경된 핵심 내용을 요약해주세요.

- presigned url 발급 API(이미지용) 구현
- 프로필 이미지 변경 API 구현

## 🧱 아키텍처 변경 요약
> 이번 작업으로 인해 변경된 주요 흐름을 적어주세요. (없으면 생략 가능)

- 예: 신규 UseCase 추가 및 외부 API 연동 어댑터 구현

## 📸 스크린샷 (선택 사항)
> API 테스트 결과 등을 첨부해주세요.
<img width="1128" height="604" alt="image" src="https://github.com/user-attachments/assets/ea12f69e-2d54-4167-82b0-2eb4c1ea043b" />

<img width="1120" height="485" alt="image" src="https://github.com/user-attachments/assets/d20af7c1-d875-4950-a76d-a66291624684" />


## ⚠️ 주의 사항 (선택)
- [ ] DB 스키마 변경이 있나요?
- [x] API 명세(Swagger)가 업데이트 되었나요?
- [ ] 새로운 환경 변수(.env)가 추가 되었나요?

## ✅ 셀프 체크리스트
- [ ] 브랜치 전략(develop)에 맞게 올렸나요?
- [ ] 커밋 컨벤션을 준수했나요?
- [ ] 불필요한 주석이나 print문은 제거했나요?
- [ ] 로컬에서 테스트는 성공했나요?