### PR TITLE
[FEAT] 카카오 로그인 sdk용 추가

### DIFF
--- a/src/main/java/com/youthexpedition/azit/modules/auth/adapter/in/web/docs/AuthControllerDocs.java
+++ b/src/main/java/com/youthexpedition/azit/modules/auth/adapter/in/web/docs/AuthControllerDocs.java
@@ -26,7 +26,7 @@ public interface AuthControllerDocs {
     @Operation(
             summary = "소셜 로그인 (애플 제외)",
             description = """
-            카카오 등 소셜 플랫폼의 인가 코드를 통해 로그인을 진행하고 JWT 토큰과 회원의 현재 상태, 최근 가입한 크루 ID를 반환합니다. <br><br>
+            카카오 등 소셜 플랫폼의 인가 코드 및 액세스 토큰을 통해 로그인을 진행하고 JWT 토큰과 회원의 현재 상태, 최근 가입한 크루 ID를 반환합니다. <br><br>
             
             **[참고 사항]** <br>
             * 보안을 위해 리프레시 토큰은 HttpOnly 쿠키에 저장되어 발급됩니다.
@@ -34,7 +34,7 @@ public interface AuthControllerDocs {
             """
     )
     @ApiErrorCodeExamples({
-            "INVALID_SOCIAL_CODE", "SOCIAL_AUTHENTICATION_FAILED"
+            "INVALID_SOCIAL_CODE", "SOCIAL_AUTHENTICATION_FAILED", "INVALID_KAKAO_ACCESS_TOKEN"
     })
     CommonResponse<SocialLoginResponse> socialLogin(
             @PathVariable SocialProvider provider, @Valid @RequestBody SocialLoginRequest request, HttpServletResponse response);

--- a/src/main/java/com/youthexpedition/azit/modules/auth/adapter/in/web/docs/AuthControllerDocs.java
+++ b/src/main/java/com/youthexpedition/azit/modules/auth/adapter/in/web/docs/AuthControllerDocs.java
@@ -34,7 +34,7 @@ public interface AuthControllerDocs {
             """
     )
     @ApiErrorCodeExamples({
-            "INVALID_SOCIAL_CODE", "SOCIAL_AUTHENTICATION_FAILED", "INVALID_KAKAO_ACCESS_TOKEN"
+            "INVALID_SOCIAL_CODE", "SOCIAL_AUTHENTICATION_FAILED", "INVALID_KAKAO_ACCESS_TOKEN", "MISSING_SOCIAL_CREDENTIAL"
     })
     CommonResponse<SocialLoginResponse> socialLogin(
             @PathVariable SocialProvider provider, @Valid @RequestBody SocialLoginRequest request, HttpServletResponse response);

--- a/src/main/java/com/youthexpedition/azit/modules/auth/adapter/in/web/dto/SocialLoginRequest.java
+++ b/src/main/java/com/youthexpedition/azit/modules/auth/adapter/in/web/dto/SocialLoginRequest.java
@@ -3,14 +3,18 @@ package com.youthexpedition.azit.modules.auth.adapter.in.web.dto;
 import com.youthexpedition.azit.modules.auth.application.port.in.command.SocialLoginCommand;
 import com.youthexpedition.azit.modules.member.domain.model.enums.SocialProvider;
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotBlank;
 
 public record SocialLoginRequest (
         @Schema(description = "소셜 서비스로부터 발급받은 인가 코드")
-        @NotBlank(message = "인가코드는 필수입니다.")
-        String authorizationCode
+        String authorizationCode,
+
+        @Schema(description = "카카오 네이티브 SDK로부터 발급받은 액세스 토큰 (네이티브 SDK)")
+        String accessToken
 ){
     public SocialLoginCommand toCommand(SocialProvider provider) {
-        return SocialLoginCommand.of(provider, this.authorizationCode);
+        if (accessToken != null && !accessToken.isBlank()) {
+            return SocialLoginCommand.ofKakaoNative(provider, accessToken);
+        }
+        return SocialLoginCommand.of(provider, authorizationCode);
     }
 }

--- a/src/main/java/com/youthexpedition/azit/modules/auth/adapter/out/external/KakaoAuthAdapter.java
+++ b/src/main/java/com/youthexpedition/azit/modules/auth/adapter/out/external/KakaoAuthAdapter.java
@@ -40,13 +40,21 @@ public class KakaoAuthAdapter implements SocialAuthPort {
     @Override
     public SocialProfile getSocialProfile(SocialLoginCommand command) {
         try {
-            // 카카오 토큰 요청
-            KakaoTokenResponse tokenResponse = kakaoAuthFeignClient.getToken(
-                    "authorization_code", clientId, redirectUri, command.authorizationCode(), clientSecret
-            );
+            String kakaoAccessToken;
+
+            if (command.accessToken() != null) {
+                // 네이티브 SDK 플로우
+                kakaoAccessToken = command.accessToken();
+            } else {
+                // 웹 OAuth 플로우, 카카오 토큰 요청
+                KakaoTokenResponse tokenResponse = kakaoAuthFeignClient.getToken(
+                        "authorization_code", clientId, redirectUri, command.authorizationCode(), clientSecret
+                );
+                kakaoAccessToken = tokenResponse.accessToken();
+            }
 
             // 카카오 사용자 정보 요청
-            KakaoUserInfoResponse userInfo = kakaoApiFeignClient.getUserInfo("Bearer " + tokenResponse.accessToken());
+            KakaoUserInfoResponse userInfo = kakaoApiFeignClient.getUserInfo("Bearer " + kakaoAccessToken);
 
             var account = userInfo.kakaoAccount();
             var profile = account.profile();
@@ -64,6 +72,9 @@ public class KakaoAuthAdapter implements SocialAuthPort {
                     .isEmailSharingEnabled(isEmailSharingEnabled)
                     .profileImageUrl(profileImageUrl)
                     .build();
+        } catch (FeignException.Unauthorized e) {
+            log.error("카카오 액세스 토큰이 유효하지 않거나 만료되었습니다: {}", e.contentUTF8());
+            throw new BusinessException(AuthErrorCode.INVALID_KAKAO_ACCESS_TOKEN);
         } catch (FeignException.BadRequest e) {
             log.error("카카오 인가 코드 검증에 실패했습니다: {}", e.contentUTF8());
             throw new BusinessException(AuthErrorCode.INVALID_SOCIAL_CODE);

--- a/src/main/java/com/youthexpedition/azit/modules/auth/application/port/in/command/SocialLoginCommand.java
+++ b/src/main/java/com/youthexpedition/azit/modules/auth/application/port/in/command/SocialLoginCommand.java
@@ -5,16 +5,22 @@ import com.youthexpedition.azit.modules.member.domain.model.enums.SocialProvider
 public record SocialLoginCommand (
         SocialProvider socialProvider,
         String authorizationCode, // 인가 코드
-        String idToken,    // 애플 전용
-        String user        // 애플 최초 가입 시 사용자 정보 (JSON)
+        String accessToken,       // 카카오 네이티브 SDK
+        String idToken,           // 애플 전용
+        String user               // 애플 최초 가입 시 사용자 정보 (JSON)
 ) {
     // 애플용
-    public static SocialLoginCommand of(SocialProvider socialProvider, String authorizationCode, String idToken, String user) { // 여러 개의 인자를 받아 적절한 객체를 생성하는 메서드
-        return new SocialLoginCommand(socialProvider, authorizationCode, idToken, user);
+    public static SocialLoginCommand of(SocialProvider socialProvider, String authorizationCode, String idToken, String user) {
+        return new SocialLoginCommand(socialProvider, authorizationCode, null, idToken, user);
     }
 
-    // 카카오용
+    // 카카오 웹 OAuth용
     public static SocialLoginCommand of(SocialProvider socialProvider, String authorizationCode) {
-        return new SocialLoginCommand(socialProvider, authorizationCode, null, null);
+        return new SocialLoginCommand(socialProvider, authorizationCode, null, null, null);
+    }
+
+    // 카카오 네이티브 SDK용
+    public static SocialLoginCommand ofKakaoNative(SocialProvider socialProvider, String accessToken) {
+        return new SocialLoginCommand(socialProvider, null, accessToken, null, null);
     }
 }

--- a/src/main/java/com/youthexpedition/azit/modules/auth/application/service/SocialLoginService.java
+++ b/src/main/java/com/youthexpedition/azit/modules/auth/application/service/SocialLoginService.java
@@ -1,11 +1,13 @@
 package com.youthexpedition.azit.modules.auth.application.service;
 
 import com.youthexpedition.azit.infrastructure.auth.jwt.JwtProvider;
+import com.youthexpedition.azit.infrastructure.exception.BusinessException;
 import com.youthexpedition.azit.modules.auth.application.port.in.SocialLoginUseCase;
 import com.youthexpedition.azit.modules.auth.application.port.in.command.SocialLoginCommand;
 import com.youthexpedition.azit.modules.auth.application.port.out.TokenPort;
 import com.youthexpedition.azit.modules.auth.application.port.out.SocialAuthPort;
 import com.youthexpedition.azit.modules.auth.domain.model.AuthResult;
+import com.youthexpedition.azit.modules.auth.domain.model.enums.AuthErrorCode;
 import com.youthexpedition.azit.modules.auth.domain.model.AuthToken;
 import com.youthexpedition.azit.modules.auth.domain.model.SocialProfile;
 import com.youthexpedition.azit.modules.crew.application.port.out.LoadCrewMemberPort;
@@ -35,6 +37,11 @@ public class SocialLoginService implements SocialLoginUseCase {
 
     @Override
     public AuthResult login(SocialLoginCommand command) {
+        if ((command.authorizationCode() == null || command.authorizationCode().isBlank()) &&
+                (command.accessToken() == null || command.accessToken().isBlank())) {
+            throw new BusinessException(AuthErrorCode.MISSING_SOCIAL_CREDENTIAL);
+        }
+
         SocialProfile profile = socialAuthPort.getSocialProfile(command);
 
         // 기존 회원 확인 및 신규 회원 가입

--- a/src/main/java/com/youthexpedition/azit/modules/auth/domain/model/enums/AuthErrorCode.java
+++ b/src/main/java/com/youthexpedition/azit/modules/auth/domain/model/enums/AuthErrorCode.java
@@ -11,6 +11,7 @@ public enum AuthErrorCode implements BaseErrorCode {
     UNAUTHORIZED("UNAUTHORIZED", "로그인이 필요합니다.", HttpStatus.UNAUTHORIZED),
 
     // 소셜 로그인
+    MISSING_SOCIAL_CREDENTIAL("MISSING_SOCIAL_CREDENTIAL", "인가 코드 또는 액세스 토큰이 필요합니다.", HttpStatus.BAD_REQUEST),
     INVALID_SOCIAL_CODE("INVALID_SOCIAL_CODE", "잘못된 소셜 인가 코드입니다.", HttpStatus.BAD_REQUEST),
     INVALID_KAKAO_ACCESS_TOKEN("INVALID_KAKAO_ACCESS_TOKEN", "유효하지 않거나 만료된 카카오 액세스 토큰입니다.", HttpStatus.UNAUTHORIZED),
     INVALID_SOCIAL_PROVIDER("INVALID_SOCIAL_PROVIDER", "지원하지 않는 소셜 로그인 제공자입니다.", HttpStatus.BAD_REQUEST),

--- a/src/main/java/com/youthexpedition/azit/modules/auth/domain/model/enums/AuthErrorCode.java
+++ b/src/main/java/com/youthexpedition/azit/modules/auth/domain/model/enums/AuthErrorCode.java
@@ -12,6 +12,7 @@ public enum AuthErrorCode implements BaseErrorCode {
 
     // 소셜 로그인
     INVALID_SOCIAL_CODE("INVALID_SOCIAL_CODE", "잘못된 소셜 인가 코드입니다.", HttpStatus.BAD_REQUEST),
+    INVALID_KAKAO_ACCESS_TOKEN("INVALID_KAKAO_ACCESS_TOKEN", "유효하지 않거나 만료된 카카오 액세스 토큰입니다.", HttpStatus.UNAUTHORIZED),
     INVALID_SOCIAL_PROVIDER("INVALID_SOCIAL_PROVIDER", "지원하지 않는 소셜 로그인 제공자입니다.", HttpStatus.BAD_REQUEST),
     SOCIAL_AUTHENTICATION_FAILED("SOCIAL_AUTHENTICATION_FAILED", "소셜 인증에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
 


### PR DESCRIPTION
## 📌 관련 이슈
- #153
## ✨ 작업 내용
> 이번 PR에서 변경된 핵심 내용을 요약해주세요.

- 카카오 로그인 네이티브 sdk 을 위한 로직 추가

## 🧱 아키텍처 변경 요약
> 이번 작업으로 인해 변경된 주요 흐름을 적어주세요. (없으면 생략 가능)

- 예: 신규 UseCase 추가 및 외부 API 연동 어댑터 구현

## 📸 스크린샷 (선택 사항)
> API 테스트 결과 등을 첨부해주세요.
<img width="872" height="728" alt="image" src="https://github.com/user-attachments/assets/a210e27f-a62a-4da2-9f4f-7b2759d06a5a" />


## ⚠️ 주의 사항 (선택)
- [ ] DB 스키마 변경이 있나요?
- [x] API 명세(Swagger)가 업데이트 되었나요?
- [ ] 새로운 환경 변수(.env)가 추가 되었나요?

## ✅ 셀프 체크리스트
- [ ] 브랜치 전략(develop)에 맞게 올렸나요?
- [ ] 커밋 컨벤션을 준수했나요?
- [ ] 불필요한 주석이나 print문은 제거했나요?
- [ ] 로컬에서 테스트는 성공했나요?