### PR TITLE
[FEAT] 크루 초대코드 재발급 API 구현

### DIFF
--- a/src/main/java/com/youthexpedition/azit/modules/crew/adapter/in/web/CrewController.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/adapter/in/web/CrewController.java
@@ -87,4 +87,10 @@ public class CrewController implements CrewControllerDocs {
         return CommonResponse.of(CommonSuccessCode.SUCCESS);
     }
 
+    @PostMapping("/{crewId}/invitation-code")
+    public CommonResponse<InvitationCodeResponse> regenerateInvitationCode(@PathVariable Long crewId, @CurrentMemberId Long memberId) {
+        InvitationCodeResponse response = crewUseCase.regenerateInvitationCode(crewId, memberId);
+
+        return CommonResponse.of(CommonSuccessCode.SUCCESS, response);
+    }
 }

--- a/src/main/java/com/youthexpedition/azit/modules/crew/adapter/in/web/docs/CrewControllerDocs.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/adapter/in/web/docs/CrewControllerDocs.java
@@ -165,4 +165,21 @@ public interface CrewControllerDocs {
             "UNAUTHORIZED", "EXPIRED_TOKEN", "INVALID_TOKEN"
     })
     CommonResponse<Void> deleteCrewMember(@PathVariable Long crewId, @PathVariable Long targetMemberId, @Parameter(hidden = true) @CurrentMemberId Long leaderId);
+
+    @Operation(
+            summary = "초대 코드 재발급",
+            description = """
+                    크루 리더가 기존 초대 코드를 폐기하고 새로운 초대 코드를 발급합니다. <br><br>
+
+                    **[제약 사항]** <br>
+                    * 해당 크루의 리더(LEADER)만 해당 API를 호출할 수 있습니다. (NOT_CREW_LEADER) <br>
+                    * 재발급 즉시 기존 코드는 무효화됩니다.
+                    """
+    )
+    @ApiErrorCodeExamples({
+            "CREW_NOT_FOUND", "NOT_CREW_LEADER", "INVITATION_CODE_GENERATION_FAILED",
+            "UNAUTHORIZED", "EXPIRED_TOKEN", "INVALID_TOKEN", "TOKEN_REUSE_DETECTED", "BLACKLISTED_TOKEN"
+    })
+    CommonResponse<InvitationCodeResponse> regenerateInvitationCode(
+            @PathVariable Long crewId, @Parameter(hidden = true) @CurrentMemberId Long memberId);
 }

--- a/src/main/java/com/youthexpedition/azit/modules/crew/adapter/in/web/docs/CrewControllerDocs.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/adapter/in/web/docs/CrewControllerDocs.java
@@ -177,7 +177,7 @@ public interface CrewControllerDocs {
                     """
     )
     @ApiErrorCodeExamples({
-            "CREW_NOT_FOUND", "NOT_CREW_LEADER", "INVITATION_CODE_GENERATION_FAILED",
+            "CREW_NOT_FOUND", "NOT_CREW_LEADER", "INVITATION_CODE_GENERATION_FAILED", "NOT_A_CREW_MEMBER",
             "UNAUTHORIZED", "EXPIRED_TOKEN", "INVALID_TOKEN", "TOKEN_REUSE_DETECTED", "BLACKLISTED_TOKEN"
     })
     CommonResponse<InvitationCodeResponse> regenerateInvitationCode(

--- a/src/main/java/com/youthexpedition/azit/modules/crew/application/port/in/CrewUseCase.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/application/port/in/CrewUseCase.java
@@ -18,4 +18,5 @@ public interface CrewUseCase {
     List<JoinRequestMemberResponse> getJoinRequests(Long crewId, Long memberId);
     CrewMemberListResponse getCrewMembers(Long crewId, Long memberId, CursorPageQuery query);
     void expelCrewMember(Long crewId, Long leaderId, Long targetMemberId);
+    InvitationCodeResponse regenerateInvitationCode(Long crewId, Long memberId);
 }

--- a/src/main/java/com/youthexpedition/azit/modules/crew/application/port/in/dto/InvitationCodeResponse.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/application/port/in/dto/InvitationCodeResponse.java
@@ -1,0 +1,12 @@
+package com.youthexpedition.azit.modules.crew.application.port.in.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record InvitationCodeResponse(
+        @Schema(description = "새로 발급된 초대 코드")
+        String invitationCode
+) {
+    public static InvitationCodeResponse of(String invitationCode) {
+        return new InvitationCodeResponse(invitationCode);
+    }
+}

--- a/src/main/java/com/youthexpedition/azit/modules/crew/application/service/CrewService.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/application/service/CrewService.java
@@ -305,6 +305,25 @@ public class CrewService implements CrewUseCase {
         saveMemberPort.save(member);
     }
 
+    @Override
+    @Retryable(
+            retryFor = {DataIntegrityViolationException.class},
+            maxAttempts = 3,
+            backoff = @Backoff(delay = 100)
+    )
+    public InvitationCodeResponse regenerateInvitationCode(Long crewId, Long memberId) {
+        validateLeader(crewId, memberId);
+
+        Crew crew = loadCrewPort.findById(crewId)
+                .orElseThrow(() -> new BusinessException(CrewErrorCode.CREW_NOT_FOUND));
+
+        String newCode = generateUniqueInvitationCode();
+        crew.updateInvitationCode(newCode);
+        saveCrewPort.save(crew);
+
+        return InvitationCodeResponse.of(newCode);
+    }
+
     // 리더 여부 체크
     private void validateLeader(Long crewId, Long memberId) {
         CrewMember crewMember = validateMember(crewId, memberId);

--- a/src/main/java/com/youthexpedition/azit/modules/crew/domain/model/Crew.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/domain/model/Crew.java
@@ -65,4 +65,8 @@ public class Crew {
         }
     }
 
+    // 초대 코드 재발급
+    public void updateInvitationCode(String invitationCode) {
+        this.invitationCode = invitationCode;
+    }
 }

--- a/src/test/java/com/youthexpedition/azit/modules/crew/application/service/CrewServiceTest.java
+++ b/src/test/java/com/youthexpedition/azit/modules/crew/application/service/CrewServiceTest.java
@@ -5,6 +5,7 @@ import com.youthexpedition.azit.modules.crew.application.port.in.command.CreateC
 import com.youthexpedition.azit.modules.crew.application.port.in.command.JoinCrewCommand;
 import com.youthexpedition.azit.modules.crew.application.port.in.command.ProcessJoinCommand;
 import com.youthexpedition.azit.modules.crew.application.port.in.dto.CreateCrewResponse;
+import com.youthexpedition.azit.modules.crew.application.port.in.dto.InvitationCodeResponse;
 import com.youthexpedition.azit.modules.crew.application.port.in.dto.JoinRequestMemberResponse;
 import com.youthexpedition.azit.modules.crew.application.port.out.LoadCrewMemberPort;
 import com.youthexpedition.azit.modules.crew.application.port.out.LoadCrewPort;
@@ -424,6 +425,103 @@ class CrewServiceTest {
             // when & then
             assertThatThrownBy(() -> crewService.getJoinRequests(crewId, nonMemberId))
                     .isInstanceOf(BusinessException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("초대 코드 재발급 테스트")
+    class RegenerateInvitationCodeTest {
+
+        @Test
+        @DisplayName("성공: 크루 리더가 초대 코드를 재발급하면 새로운 코드가 반환되고 크루에 저장된다.")
+        void regenerateInvitationCode_Success() {
+            // given
+            Long crewId = 100L;
+            Long leaderId = 1L;
+            String oldCode = "OLDCOD";
+
+            CrewMember leader = CrewMember.builder()
+                    .crewId(crewId)
+                    .memberId(leaderId)
+                    .role(CrewMemberRole.LEADER)
+                    .status(CrewMemberStatus.JOINED)
+                    .build();
+            given(loadCrewMemberPort.findByCrewIdAndMemberId(crewId, leaderId)).willReturn(Optional.of(leader));
+
+            Crew crew = Crew.builder()
+                    .id(crewId)
+                    .invitationCode(oldCode)
+                    .build();
+            given(loadCrewPort.findById(crewId)).willReturn(Optional.of(crew));
+
+            // 새 코드는 항상 유일하다고 가정
+            given(loadCrewPort.existsByInvitationCode(anyString())).willReturn(false);
+
+            // when
+            InvitationCodeResponse response = crewService.regenerateInvitationCode(crewId, leaderId);
+
+            // then
+            assertThat(response.invitationCode()).isNotBlank();
+            assertThat(response.invitationCode()).isNotEqualTo(oldCode);
+            verify(saveCrewPort, times(1)).save(crew);
+        }
+
+        @Test
+        @DisplayName("실패 (권한 없음): 리더가 아닌 일반 멤버가 재발급을 시도하면 NOT_CREW_LEADER 예외가 발생한다.")
+        void regenerateInvitationCode_Fail_NotLeader() {
+            // given
+            Long crewId = 100L;
+            Long memberId = 2L;
+
+            CrewMember member = CrewMember.builder()
+                    .crewId(crewId)
+                    .memberId(memberId)
+                    .role(CrewMemberRole.MEMBER)
+                    .status(CrewMemberStatus.JOINED)
+                    .build();
+            given(loadCrewMemberPort.findByCrewIdAndMemberId(crewId, memberId)).willReturn(Optional.of(member));
+
+            // when & then
+            assertThatThrownBy(() -> crewService.regenerateInvitationCode(crewId, memberId))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessageContaining(CrewErrorCode.NOT_CREW_LEADER.getMessage());
+        }
+
+        @Test
+        @DisplayName("실패 (크루 멤버 아님): 해당 크루에 속하지 않은 사용자가 재발급을 시도하면 NOT_A_CREW_MEMBER 예외가 발생한다.")
+        void regenerateInvitationCode_Fail_NotMember() {
+            // given
+            Long crewId = 100L;
+            Long nonMemberId = 999L;
+
+            given(loadCrewMemberPort.findByCrewIdAndMemberId(crewId, nonMemberId)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> crewService.regenerateInvitationCode(crewId, nonMemberId))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessageContaining(CrewErrorCode.NOT_A_CREW_MEMBER.getMessage());
+        }
+
+        @Test
+        @DisplayName("실패 (크루 없음): 유효하지 않은 crewId로 재발급을 시도하면 CREW_NOT_FOUND 예외가 발생한다.")
+        void regenerateInvitationCode_Fail_CrewNotFound() {
+            // given
+            Long crewId = 999L;
+            Long leaderId = 1L;
+
+            CrewMember leader = CrewMember.builder()
+                    .crewId(crewId)
+                    .memberId(leaderId)
+                    .role(CrewMemberRole.LEADER)
+                    .status(CrewMemberStatus.JOINED)
+                    .build();
+            given(loadCrewMemberPort.findByCrewIdAndMemberId(crewId, leaderId)).willReturn(Optional.of(leader));
+            given(loadCrewPort.findById(crewId)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> crewService.regenerateInvitationCode(crewId, leaderId))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessageContaining(CrewErrorCode.CREW_NOT_FOUND.getMessage());
         }
     }
 


### PR DESCRIPTION
## 📌 관련 이슈
- closes #156

## ✨ 작업 내용
> 이번 PR에서 변경된 핵심 내용을 요약해주세요.

- 크루 초대코드 재발급 API 구현

## 🧱 아키텍처 변경 요약
> 이번 작업으로 인해 변경된 주요 흐름을 적어주세요. (없으면 생략 가능)

- 예: 신규 UseCase 추가 및 외부 API 연동 어댑터 구현

## 📸 스크린샷 (선택 사항)
> API 테스트 결과 등을 첨부해주세요.
<img width="1122" height="510" alt="image" src="https://github.com/user-attachments/assets/3c07c9aa-b77d-4f1d-9913-3d76bed43e7d" />


## ⚠️ 주의 사항 (선택)
- [ ] DB 스키마 변경이 있나요?
- [x] API 명세(Swagger)가 업데이트 되었나요?
- [ ] 새로운 환경 변수(.env)가 추가 되었나요?

## ✅ 셀프 체크리스트
- [ ] 브랜치 전략(develop)에 맞게 올렸나요?
- [ ] 커밋 컨벤션을 준수했나요?
- [ ] 불필요한 주석이나 print문은 제거했나요?
- [ ] 로컬에서 테스트는 성공했나요?