### PR TITLE
[FEAT] 크루 방출/탈퇴 관련 로직 고도화 및 신규 api 추가

### DIFF
--- a/src/main/java/com/youthexpedition/azit/infrastructure/config/SecurityConfig.java
+++ b/src/main/java/com/youthexpedition/azit/infrastructure/config/SecurityConfig.java
@@ -73,7 +73,7 @@ public class SecurityConfig {
 
                         // 사용자 인증 시 상태 상관없이 허용
                         .requestMatchers(
-                                "/api/v1/auth/logout", "/api/v1/members/**"
+                                "/api/v1/auth/logout", "/api/v1/members/**", "/api/v1/images/**"
                         ).authenticated()
                         // 나머지 API: 정회원(ACTIVE) 상태만 접근 가능
                         .anyRequest().hasAuthority("STATUS_ACTIVE")

--- a/src/main/java/com/youthexpedition/azit/modules/crew/adapter/in/web/CrewController.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/adapter/in/web/CrewController.java
@@ -80,6 +80,13 @@ public class CrewController implements CrewControllerDocs {
         return CommonResponse.of(CommonSuccessCode.SUCCESS, response);
     }
 
+    @DeleteMapping("/{crewId}/members/me")
+    public CommonResponse<Void> exitCrew(@PathVariable Long crewId, @CurrentMemberId Long memberId) {
+        crewUseCase.exitCrew(crewId, memberId);
+
+        return CommonResponse.of(CommonSuccessCode.SUCCESS);
+    }
+
     @DeleteMapping("/{crewId}/members/{targetMemberId}")
     public CommonResponse<Void> deleteCrewMember(@PathVariable Long crewId, @PathVariable Long targetMemberId, @CurrentMemberId Long leaderId) {
         crewUseCase.expelCrewMember(crewId, leaderId, targetMemberId);

--- a/src/main/java/com/youthexpedition/azit/modules/crew/adapter/in/web/docs/CrewControllerDocs.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/adapter/in/web/docs/CrewControllerDocs.java
@@ -150,12 +150,12 @@ public interface CrewControllerDocs {
     CommonResponse<CrewMemberListResponse> getCrewMembers(@PathVariable Long crewId, @CurrentMemberId Long memberId, CursorPageQuery query);
 
     @Operation(
-            summary = "크루 나가기",
+            summary = "크루 탈퇴",
             description = """
             로그인한 사용자가 특정 크루에서 자진 탈퇴합니다. <br><br>
 
             **[제약 사항]** <br>
-            * 크루 리더(LEADER)는 크루 나가기가 불가합니다. 리더 권한 위임 또는 크루 해산이 필요합니다. (CANNOT_WITHDRAW_AS_LEADER) <br>
+            * 크루 리더(LEADER)는 크루 탈퇴가 불가합니다. 리더 권한 위임 또는 크루 해산이 필요합니다. (CANNOT_WITHDRAW_AS_LEADER) <br>
             * 탈퇴 후 24시간 이내에는 동일 크루 재가입 요청이 차단됩니다. (EXIT_REJOINING_COOLDOWN) <br>
             * 가입 완료(JOINED) 상태인 경우에만 탈퇴가 가능합니다. (NOT_A_CREW_MEMBER)
             """

--- a/src/main/java/com/youthexpedition/azit/modules/crew/adapter/in/web/docs/CrewControllerDocs.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/adapter/in/web/docs/CrewControllerDocs.java
@@ -49,10 +49,11 @@ public interface CrewControllerDocs {
             **[제약 사항]** <br>
             * 본인이 리더인 크루이거나 이미 멤버로 등록된 크루에는 재신청이 불가합니다. (ALREADY_JOINED_CREW)
             * 유효하지 않은 초대 코드를 입력할 경우 가입이 불가합니다. (CREW_NOT_FOUND)
+            * 방출된 크루가 존재할 시 24시간 내에는 재가입 신청이 불가합니다. (EXPELLED_REJOINING_COOLDOWN)
             """
     )
     @ApiErrorCodeExamples({
-            "CREW_NOT_FOUND", "ALREADY_JOINED_CREW",
+            "CREW_NOT_FOUND", "ALREADY_JOINED_CREW", "EXPELLED_REJOINING_COOLDOWN",
             "UNAUTHORIZED", "EXPIRED_TOKEN", "INVALID_TOKEN", "TOKEN_REUSE_DETECTED", "BLACKLISTED_TOKEN"
     })
     CommonResponse<Void> joinCrew(@Parameter(hidden = true) @CurrentMemberId Long memberId, @Valid @RequestBody JoinCrewRequest request);
@@ -147,6 +148,23 @@ public interface CrewControllerDocs {
             "UNAUTHORIZED", "EXPIRED_TOKEN", "INVALID_TOKEN", "TOKEN_REUSE_DETECTED", "BLACKLISTED_TOKEN"
     })
     CommonResponse<CrewMemberListResponse> getCrewMembers(@PathVariable Long crewId, @CurrentMemberId Long memberId, CursorPageQuery query);
+
+    @Operation(
+            summary = "크루 나가기",
+            description = """
+            로그인한 사용자가 특정 크루에서 자진 탈퇴합니다. <br><br>
+
+            **[제약 사항]** <br>
+            * 크루 리더(LEADER)는 크루 나가기가 불가합니다. 리더 권한 위임 또는 크루 해산이 필요합니다. (CANNOT_WITHDRAW_AS_LEADER) <br>
+            * 탈퇴 후 24시간 이내에는 동일 크루 재가입 요청이 차단됩니다. (EXIT_REJOINING_COOLDOWN) <br>
+            * 가입 완료(JOINED) 상태인 경우에만 탈퇴가 가능합니다. (NOT_A_CREW_MEMBER)
+            """
+    )
+    @ApiErrorCodeExamples({
+            "CANNOT_WITHDRAW_AS_LEADER", "NOT_A_CREW_MEMBER", "CREW_NOT_FOUND", "EXIT_REJOINING_COOLDOWN",
+            "UNAUTHORIZED", "EXPIRED_TOKEN", "INVALID_TOKEN", "TOKEN_REUSE_DETECTED", "BLACKLISTED_TOKEN"
+    })
+    CommonResponse<Void> exitCrew(@PathVariable Long crewId, @Parameter(hidden = true) @CurrentMemberId Long memberId);
 
     @Operation(
             summary = "크루 멤버 방출",

--- a/src/main/java/com/youthexpedition/azit/modules/crew/adapter/out/persistence/entity/CrewMemberEntity.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/adapter/out/persistence/entity/CrewMemberEntity.java
@@ -6,6 +6,8 @@ import com.youthexpedition.azit.modules.crew.domain.model.enums.CrewMemberStatus
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.time.LocalDateTime;
+
 @Entity
 @Table(name = "crew_member")
 @Getter
@@ -32,4 +34,7 @@ public class CrewMemberEntity extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 20)
     private CrewMemberStatus status;
+
+    @Column(name = "expelled_at")
+    private LocalDateTime expelledAt;
 }

--- a/src/main/java/com/youthexpedition/azit/modules/crew/adapter/out/persistence/entity/CrewMemberEntity.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/adapter/out/persistence/entity/CrewMemberEntity.java
@@ -37,4 +37,7 @@ public class CrewMemberEntity extends BaseTimeEntity {
 
     @Column(name = "expelled_at")
     private LocalDateTime expelledAt;
+
+    @Column(name = "exited_at")
+    private LocalDateTime exitedAt;
 }

--- a/src/main/java/com/youthexpedition/azit/modules/crew/adapter/out/persistence/mapper/CrewMemberMapper.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/adapter/out/persistence/mapper/CrewMemberMapper.java
@@ -17,6 +17,7 @@ public class CrewMemberMapper {
                 .memberId(entity.getMemberId())
                 .role(entity.getRole())
                 .status(entity.getStatus())
+                .expelledAt(entity.getExpelledAt())
                 .createdAt(entity.getCreatedAt())
                 .updatedAt(entity.getUpdatedAt())
                 .build();
@@ -29,6 +30,7 @@ public class CrewMemberMapper {
                 .memberId(domain.getMemberId())
                 .role(domain.getRole())
                 .status(domain.getStatus())
+                .expelledAt(domain.getExpelledAt())
                 .build();
     }
 }

--- a/src/main/java/com/youthexpedition/azit/modules/crew/adapter/out/persistence/mapper/CrewMemberMapper.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/adapter/out/persistence/mapper/CrewMemberMapper.java
@@ -18,6 +18,7 @@ public class CrewMemberMapper {
                 .role(entity.getRole())
                 .status(entity.getStatus())
                 .expelledAt(entity.getExpelledAt())
+                .exitedAt(entity.getExitedAt())
                 .createdAt(entity.getCreatedAt())
                 .updatedAt(entity.getUpdatedAt())
                 .build();
@@ -31,6 +32,7 @@ public class CrewMemberMapper {
                 .role(domain.getRole())
                 .status(domain.getStatus())
                 .expelledAt(domain.getExpelledAt())
+                .exitedAt(domain.getExitedAt())
                 .build();
     }
 }

--- a/src/main/java/com/youthexpedition/azit/modules/crew/application/port/in/CrewUseCase.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/application/port/in/CrewUseCase.java
@@ -18,5 +18,6 @@ public interface CrewUseCase {
     List<JoinRequestMemberResponse> getJoinRequests(Long crewId, Long memberId);
     CrewMemberListResponse getCrewMembers(Long crewId, Long memberId, CursorPageQuery query);
     void expelCrewMember(Long crewId, Long leaderId, Long targetMemberId);
+    void exitCrew(Long crewId, Long memberId);
     InvitationCodeResponse regenerateInvitationCode(Long crewId, Long memberId);
 }

--- a/src/main/java/com/youthexpedition/azit/modules/crew/application/service/CrewService.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/application/service/CrewService.java
@@ -323,12 +323,7 @@ public class CrewService implements CrewUseCase {
     public void exitCrew(Long crewId, Long memberId) {
         LocalDateTime now = LocalDateTime.now();
 
-        CrewMember crewMember = loadCrewMemberPort.findByCrewIdAndMemberId(crewId, memberId)
-                .orElseThrow(() -> new BusinessException(CrewErrorCode.NOT_A_CREW_MEMBER));
-
-        if (crewMember.getStatus() != CrewMemberStatus.JOINED) {
-            throw new BusinessException(CrewErrorCode.NOT_A_CREW_MEMBER);
-        }
+        CrewMember crewMember = validateMember(crewId, memberId);
 
         // 리더는 크루 나가기 불가
         if (crewMember.getRole() == CrewMemberRole.LEADER) {

--- a/src/main/java/com/youthexpedition/azit/modules/crew/application/service/CrewService.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/application/service/CrewService.java
@@ -128,6 +128,11 @@ public class CrewService implements CrewUseCase {
                                 throw new BusinessException(CrewErrorCode.EXPELLED_REJOINING_COOLDOWN);
                             }
 
+                            // 자진 탈퇴 후 24시간 이내 재가입 차단
+                            if (existingMember.getStatus() == CrewMemberStatus.EXITED && existingMember.isExitCooldownActive(now)) {
+                                throw new BusinessException(CrewErrorCode.EXIT_REJOINING_COOLDOWN);
+                            }
+
                             // 탈퇴, 방출(쿨다운 지남), 거절 상태일 경우 재신청
                             existingMember.reJoin();
                             saveCrewMemberPort.save(existingMember);
@@ -311,6 +316,51 @@ public class CrewService implements CrewUseCase {
 
         member.expel();
         saveMemberPort.save(member);
+    }
+
+    @Override
+    @Transactional
+    public void exitCrew(Long crewId, Long memberId) {
+        LocalDateTime now = LocalDateTime.now();
+
+        CrewMember crewMember = loadCrewMemberPort.findByCrewIdAndMemberId(crewId, memberId)
+                .orElseThrow(() -> new BusinessException(CrewErrorCode.NOT_A_CREW_MEMBER));
+
+        if (crewMember.getStatus() != CrewMemberStatus.JOINED) {
+            throw new BusinessException(CrewErrorCode.NOT_A_CREW_MEMBER);
+        }
+
+        // 리더는 크루 나가기 불가
+        if (crewMember.getRole() == CrewMemberRole.LEADER) {
+            throw new BusinessException(CrewErrorCode.CANNOT_WITHDRAW_AS_LEADER);
+        }
+
+        // 미래 일정 정리 (생성한 일정 취소, 참여 명단 제거)
+        crewScheduleUseCase.cleanupForExpelledMemberSchedules(crewId, memberId);
+
+        // 크루 멤버 상태 EXITED 변경
+        crewMember.exit(now);
+        saveCrewMemberPort.save(crewMember);
+
+        // 크루 인원 수 1명 감소
+        Crew crew = loadCrewPort.findById(crewId)
+                .orElseThrow(() -> new BusinessException(CrewErrorCode.CREW_NOT_FOUND));
+
+        log.info("[CREW] crewId: {} 에서 memberId: {} 가 자진 탈퇴하여 크루 인원 수가 감소합니다.", crewId, memberId);
+        crew.decreaseMemberCount();
+        saveCrewPort.save(crew);
+
+        // 가입된 잔여 크루 확인 후 멤버 상태 변경
+        Member member = loadMemberPort.findById(memberId)
+                .orElseThrow(() -> new BusinessException(MemberErrorCode.MEMBER_NOT_FOUND));
+
+        long joinedCrewCount = loadCrewMemberPort.countJoinedCrewsByMemberId(memberId);
+
+        if (joinedCrewCount == 0) {
+            log.info("[CREW] memberId: {}, 가입된 크루가 없으므로 온보딩 상태로 변경합니다.", memberId);
+            member.resetToOnboarding();
+            saveMemberPort.save(member);
+        }
     }
 
     @Override

--- a/src/main/java/com/youthexpedition/azit/modules/crew/application/service/CrewService.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/application/service/CrewService.java
@@ -35,6 +35,7 @@ import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Service
@@ -111,6 +112,8 @@ public class CrewService implements CrewUseCase {
         Crew crew = loadCrewPort.findByInvitationCode(command.invitationCode())
                 .orElseThrow(() -> new BusinessException(CrewErrorCode.CREW_NOT_FOUND));
 
+        LocalDateTime now = LocalDateTime.now();
+
         // 이미 가입된 멤버인지 확인
         loadCrewMemberPort.findByCrewIdAndMemberId(crew.getId(), command.memberId())
                 .ifPresentOrElse(
@@ -120,7 +123,12 @@ public class CrewService implements CrewUseCase {
                                 throw new BusinessException(CrewErrorCode.ALREADY_JOINED_CREW);
                             }
 
-                            // 탈퇴, 방출, 거절 상태일 경우 재신청
+                            // 방출 후 24시간 이내 재가입 차단
+                            if (existingMember.getStatus() == CrewMemberStatus.EXPELLED && existingMember.isRejoinCooldownActive(now)) {
+                                throw new BusinessException(CrewErrorCode.EXPELLED_REJOINING_COOLDOWN);
+                            }
+
+                            // 탈퇴, 방출(쿨다운 지남), 거절 상태일 경우 재신청
                             existingMember.reJoin();
                             saveCrewMemberPort.save(existingMember);
                         },
@@ -272,8 +280,8 @@ public class CrewService implements CrewUseCase {
         // 멤버 스케줄 삭제
         crewScheduleUseCase.cleanupForExpelledMemberSchedules(crewId, targetMemberId);
 
-        // 멤버 상태 EXITED 변경
-        targetMember.expel();
+        // 멤버 상태 EXPELLED 변경
+        targetMember.expel(LocalDateTime.now());
         saveCrewMemberPort.save(targetMember);
 
         // 크루 인원 수 1명 감소

--- a/src/main/java/com/youthexpedition/azit/modules/crew/application/service/mapper/CrewScheduleResponseMapper.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/application/service/mapper/CrewScheduleResponseMapper.java
@@ -8,7 +8,6 @@ import com.youthexpedition.azit.modules.crew.application.port.out.query.MemberPr
 import com.youthexpedition.azit.modules.crew.domain.model.CrewMember;
 import com.youthexpedition.azit.modules.crew.domain.model.CrewSchedule;
 import com.youthexpedition.azit.modules.crew.domain.model.enums.CrewMemberRole;
-import com.youthexpedition.azit.modules.crew.domain.model.enums.CrewMemberStatus;
 import com.youthexpedition.azit.modules.crew.domain.model.enums.RunType;
 import com.youthexpedition.azit.modules.member.application.port.in.dto.MyAttendanceLogResponse;
 import com.youthexpedition.azit.modules.member.application.port.in.dto.MyAttendanceMonthlyListResponse;
@@ -42,20 +41,18 @@ public class CrewScheduleResponseMapper {
         boolean hasMoreParticipants = allActiveParticipants.size() > PARTICIPANT_PREVIEW_LIMIT;
 
         Long creatorId = schedule.getCreatorId();
-        // 기본값 세팅 (마스킹 처리)
+        // 앱 탈퇴 등으로 계정이 완전히 삭제된 경우 null 처리 (프론트에서 비식별화)
         String creatorNickname = null;
         String creatorProfileImageUrl = null;
         CrewMemberRole creatorRole = CrewMemberRole.MEMBER;
 
-        // 생성자가 EXITED/EXPELLED 상태 아닐 때 생성자 정보 추가
-        if (profileMap.containsKey(creatorId) && crewMemberMap.containsKey(creatorId)) {
-            CrewMember creator = crewMemberMap.get(creatorId);
-
-            if (creator.getStatus() != CrewMemberStatus.EXITED && creator.getStatus() != CrewMemberStatus.EXPELLED) {
-                MemberProfileDto creatorProfile = profileMap.get(creatorId);
-                creatorNickname = creatorProfile.nickname();
-                creatorProfileImageUrl = imageUrlFormatUtil.buildFullImageUrl(creatorProfile.profileImageUrl());
-                creatorRole = creator.getRole();
+        // 크루 탈퇴/방출 여부와 무관하게 계정이 존재하면 프로필 그대로 노출
+        if (profileMap.containsKey(creatorId)) {
+            MemberProfileDto creatorProfile = profileMap.get(creatorId);
+            creatorNickname = creatorProfile.nickname();
+            creatorProfileImageUrl = imageUrlFormatUtil.buildFullImageUrl(creatorProfile.profileImageUrl());
+            if (crewMemberMap.containsKey(creatorId)) {
+                creatorRole = crewMemberMap.get(creatorId).getRole();
             }
         }
 
@@ -102,8 +99,9 @@ public class CrewScheduleResponseMapper {
                     MemberProfileDto profile = profileMap.get(id);
                     CrewMember crewMember = crewMemberMap.get(id);
 
-                    // 프로필이 없거나, 크루 멤버 정보가 없거나, 크루 방출/탈퇴 상태인 경우 마스킹 처리
-                    if (profile == null || crewMember == null || crewMember.getStatus() == CrewMemberStatus.EXITED || crewMember.getStatus() == CrewMemberStatus.EXPELLED) {
+                    // 앱 탈퇴 등으로 계정이 완전히 삭제된 경우 비식별화 처리
+                    // 크루 탈퇴/방출 상태(EXITED/EXPELLED)여도 계정이 존재하면 프로필 그대로 노출
+                    if (profile == null || crewMember == null) {
                         return ParticipantResponse.of(
                                 id, // 페이징 위해 살려둠
                                 null,

--- a/src/main/java/com/youthexpedition/azit/modules/crew/domain/model/CrewMember.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/domain/model/CrewMember.java
@@ -22,6 +22,8 @@ public class CrewMember {
     private final LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 
+    private static final long REJOINING_COOLDOWN_HOURS = 24;
+
     // 리더 등록
     public static CrewMember createAsLeader(Long crewId, Long memberId) {
         return CrewMember.builder()
@@ -66,7 +68,7 @@ public class CrewMember {
     // 자진 탈퇴 후 재가입 쿨다운 여부 확인 (24시간)
     public boolean isExitCooldownActive(LocalDateTime now) {
         if (this.exitedAt == null) return false;
-        return this.exitedAt.plusHours(24).isAfter(now);
+        return this.exitedAt.plusHours(REJOINING_COOLDOWN_HOURS).isAfter(now);
     }
 
     // 크루 방출
@@ -78,7 +80,7 @@ public class CrewMember {
     // 방출 후 재가입 쿨다운 여부 확인 (24시간)
     public boolean isRejoinCooldownActive(LocalDateTime now) {
         if (this.expelledAt == null) return false;
-        return this.expelledAt.plusHours(24).isAfter(now);
+        return this.expelledAt.plusHours(REJOINING_COOLDOWN_HOURS).isAfter(now);
     }
 
     // 가입 재신청

--- a/src/main/java/com/youthexpedition/azit/modules/crew/domain/model/CrewMember.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/domain/model/CrewMember.java
@@ -17,6 +17,7 @@ public class CrewMember {
     private final Long memberId;
     private CrewMemberRole role;
     private CrewMemberStatus status;
+    private LocalDateTime expelledAt;
     private final LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 
@@ -61,8 +62,15 @@ public class CrewMember {
     }
 
     // 크루 방출
-    public void expel() {
+    public void expel(LocalDateTime expelledAt) {
         this.status = CrewMemberStatus.EXPELLED;
+        this.expelledAt = expelledAt;
+    }
+
+    // 방출 후 재가입 쿨다운 여부 확인 (24시간)
+    public boolean isRejoinCooldownActive(LocalDateTime now) {
+        if (this.expelledAt == null) return false;
+        return this.expelledAt.plusHours(24).isAfter(now);
     }
 
     // 가입 재신청

--- a/src/main/java/com/youthexpedition/azit/modules/crew/domain/model/CrewMember.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/domain/model/CrewMember.java
@@ -18,6 +18,7 @@ public class CrewMember {
     private CrewMemberRole role;
     private CrewMemberStatus status;
     private LocalDateTime expelledAt;
+    private LocalDateTime exitedAt;
     private final LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 
@@ -57,8 +58,15 @@ public class CrewMember {
     }
 
     // 크루 탈퇴
-    public void exit() {
+    public void exit(LocalDateTime exitedAt) {
         this.status = CrewMemberStatus.EXITED;
+        this.exitedAt = exitedAt;
+    }
+
+    // 자진 탈퇴 후 재가입 쿨다운 여부 확인 (24시간)
+    public boolean isExitCooldownActive(LocalDateTime now) {
+        if (this.exitedAt == null) return false;
+        return this.exitedAt.plusHours(24).isAfter(now);
     }
 
     // 크루 방출

--- a/src/main/java/com/youthexpedition/azit/modules/crew/domain/model/enums/CrewErrorCode.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/domain/model/enums/CrewErrorCode.java
@@ -21,6 +21,7 @@ public enum CrewErrorCode implements BaseErrorCode {
     CREW_MEMBER_NOT_FOUND("CREW_MEMBER_NOT_FOUND", "가입한 크루가 없습니다.", HttpStatus.NOT_FOUND),
     CANNOT_KICK_SELF("CANNOT_KICK_SELF", "스스로를 방출할 수 없습니다.", HttpStatus.BAD_REQUEST),
     CANNOT_WITHDRAW_AS_LEADER("CANNOT_WITHDRAW_AS_LEADER", "리더로 활동 중인 크루에 다른 멤버가 존재하여 탈퇴가 불가능합니다.", HttpStatus.BAD_REQUEST),
+    EXPELLED_REJOINING_COOLDOWN("EXPELLED_REJOINING_COOLDOWN", "방출 후 24시간이 지나지 않아 재가입 요청이 불가합니다.", HttpStatus.BAD_REQUEST),
 
     // 일정 관련
     INVALID_SCHEDULE_TIME("INVALID_SCHEDULE_TIME", "유효하지 않은 일정 시간입니다.", HttpStatus.BAD_REQUEST),

--- a/src/main/java/com/youthexpedition/azit/modules/crew/domain/model/enums/CrewErrorCode.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/domain/model/enums/CrewErrorCode.java
@@ -21,7 +21,7 @@ public enum CrewErrorCode implements BaseErrorCode {
     CREW_MEMBER_NOT_FOUND("CREW_MEMBER_NOT_FOUND", "가입한 크루가 없습니다.", HttpStatus.NOT_FOUND),
     CANNOT_KICK_SELF("CANNOT_KICK_SELF", "스스로를 방출할 수 없습니다.", HttpStatus.BAD_REQUEST),
     CANNOT_WITHDRAW_AS_LEADER("CANNOT_WITHDRAW_AS_LEADER", "크루 리더는 크루 탈퇴가 불가합니다. 리더 권한을 위임하거나 크루를 해산해 주세요.", HttpStatus.BAD_REQUEST),
-    CANNOT_APP_WITHDRAW_AS_LEADER("CANNOT_SERVICE_WITHDRAW_AS_LEADER", "리더로 활동 중인 크루가 있습니다. 권한을 위임하거나 크루를 해산한 후 서비스를 탈퇴할 수 있습니다.", HttpStatus.BAD_REQUEST),
+    CANNOT_SERVICE_WITHDRAW_AS_LEADER("CANNOT_SERVICE_WITHDRAW_AS_LEADER", "리더로 활동 중인 크루가 있습니다. 권한을 위임하거나 크루를 해산한 후 서비스를 탈퇴할 수 있습니다.", HttpStatus.BAD_REQUEST),
     EXPELLED_REJOINING_COOLDOWN("EXPELLED_REJOINING_COOLDOWN", "방출 후 24시간이 지나지 않아 재가입 요청이 불가합니다.", HttpStatus.BAD_REQUEST),
     EXIT_REJOINING_COOLDOWN("EXIT_REJOINING_COOLDOWN", "탈퇴 후 24시간이 지나지 않아 재가입 요청이 불가합니다.", HttpStatus.BAD_REQUEST),
 

--- a/src/main/java/com/youthexpedition/azit/modules/crew/domain/model/enums/CrewErrorCode.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/domain/model/enums/CrewErrorCode.java
@@ -21,6 +21,7 @@ public enum CrewErrorCode implements BaseErrorCode {
     CREW_MEMBER_NOT_FOUND("CREW_MEMBER_NOT_FOUND", "가입한 크루가 없습니다.", HttpStatus.NOT_FOUND),
     CANNOT_KICK_SELF("CANNOT_KICK_SELF", "스스로를 방출할 수 없습니다.", HttpStatus.BAD_REQUEST),
     CANNOT_WITHDRAW_AS_LEADER("CANNOT_WITHDRAW_AS_LEADER", "크루 리더는 크루 나가기가 불가합니다. 리더 권한을 위임하거나 크루를 해산해 주세요.", HttpStatus.BAD_REQUEST),
+    CANNOT_APP_WITHDRAW_AS_LEADER("CANNOT_APP_WITHDRAW_AS_LEADER", "리더로 활동 중인 크루가 있습니다. 권한을 위임하거나 크루를 삭제한 후 탈퇴할 수 있습니다.", HttpStatus.BAD_REQUEST),
     EXPELLED_REJOINING_COOLDOWN("EXPELLED_REJOINING_COOLDOWN", "방출 후 24시간이 지나지 않아 재가입 요청이 불가합니다.", HttpStatus.BAD_REQUEST),
     EXIT_REJOINING_COOLDOWN("EXIT_REJOINING_COOLDOWN", "탈퇴 후 24시간이 지나지 않아 재가입 요청이 불가합니다.", HttpStatus.BAD_REQUEST),
 

--- a/src/main/java/com/youthexpedition/azit/modules/crew/domain/model/enums/CrewErrorCode.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/domain/model/enums/CrewErrorCode.java
@@ -20,8 +20,8 @@ public enum CrewErrorCode implements BaseErrorCode {
     NOT_A_CREW_MEMBER("NOT_A_CREW_MEMBER", "해당 크루의 멤버가 아닙니다.", HttpStatus.FORBIDDEN),
     CREW_MEMBER_NOT_FOUND("CREW_MEMBER_NOT_FOUND", "가입한 크루가 없습니다.", HttpStatus.NOT_FOUND),
     CANNOT_KICK_SELF("CANNOT_KICK_SELF", "스스로를 방출할 수 없습니다.", HttpStatus.BAD_REQUEST),
-    CANNOT_WITHDRAW_AS_LEADER("CANNOT_WITHDRAW_AS_LEADER", "크루 리더는 크루 나가기가 불가합니다. 리더 권한을 위임하거나 크루를 해산해 주세요.", HttpStatus.BAD_REQUEST),
-    CANNOT_APP_WITHDRAW_AS_LEADER("CANNOT_APP_WITHDRAW_AS_LEADER", "리더로 활동 중인 크루가 있습니다. 권한을 위임하거나 크루를 삭제한 후 탈퇴할 수 있습니다.", HttpStatus.BAD_REQUEST),
+    CANNOT_WITHDRAW_AS_LEADER("CANNOT_WITHDRAW_AS_LEADER", "크루 리더는 크루 탈퇴가 불가합니다. 리더 권한을 위임하거나 크루를 해산해 주세요.", HttpStatus.BAD_REQUEST),
+    CANNOT_APP_WITHDRAW_AS_LEADER("CANNOT_SERVICE_WITHDRAW_AS_LEADER", "리더로 활동 중인 크루가 있습니다. 권한을 위임하거나 크루를 해산한 후 서비스를 탈퇴할 수 있습니다.", HttpStatus.BAD_REQUEST),
     EXPELLED_REJOINING_COOLDOWN("EXPELLED_REJOINING_COOLDOWN", "방출 후 24시간이 지나지 않아 재가입 요청이 불가합니다.", HttpStatus.BAD_REQUEST),
     EXIT_REJOINING_COOLDOWN("EXIT_REJOINING_COOLDOWN", "탈퇴 후 24시간이 지나지 않아 재가입 요청이 불가합니다.", HttpStatus.BAD_REQUEST),
 

--- a/src/main/java/com/youthexpedition/azit/modules/crew/domain/model/enums/CrewErrorCode.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/domain/model/enums/CrewErrorCode.java
@@ -20,8 +20,9 @@ public enum CrewErrorCode implements BaseErrorCode {
     NOT_A_CREW_MEMBER("NOT_A_CREW_MEMBER", "해당 크루의 멤버가 아닙니다.", HttpStatus.FORBIDDEN),
     CREW_MEMBER_NOT_FOUND("CREW_MEMBER_NOT_FOUND", "가입한 크루가 없습니다.", HttpStatus.NOT_FOUND),
     CANNOT_KICK_SELF("CANNOT_KICK_SELF", "스스로를 방출할 수 없습니다.", HttpStatus.BAD_REQUEST),
-    CANNOT_WITHDRAW_AS_LEADER("CANNOT_WITHDRAW_AS_LEADER", "리더로 활동 중인 크루에 다른 멤버가 존재하여 탈퇴가 불가능합니다.", HttpStatus.BAD_REQUEST),
+    CANNOT_WITHDRAW_AS_LEADER("CANNOT_WITHDRAW_AS_LEADER", "크루 리더는 크루 나가기가 불가합니다. 리더 권한을 위임하거나 크루를 해산해 주세요.", HttpStatus.BAD_REQUEST),
     EXPELLED_REJOINING_COOLDOWN("EXPELLED_REJOINING_COOLDOWN", "방출 후 24시간이 지나지 않아 재가입 요청이 불가합니다.", HttpStatus.BAD_REQUEST),
+    EXIT_REJOINING_COOLDOWN("EXIT_REJOINING_COOLDOWN", "탈퇴 후 24시간이 지나지 않아 재가입 요청이 불가합니다.", HttpStatus.BAD_REQUEST),
 
     // 일정 관련
     INVALID_SCHEDULE_TIME("INVALID_SCHEDULE_TIME", "유효하지 않은 일정 시간입니다.", HttpStatus.BAD_REQUEST),

--- a/src/main/java/com/youthexpedition/azit/modules/member/adapter/in/web/MemberController.java
+++ b/src/main/java/com/youthexpedition/azit/modules/member/adapter/in/web/MemberController.java
@@ -114,4 +114,11 @@ public class MemberController implements MemberControllerDocs {
 
         return CommonResponse.of(CommonSuccessCode.SUCCESS);
     }
+
+    @PatchMapping("/me/profile-image/default")
+    public CommonResponse<Void> resetProfileImageToDefault(@CurrentMemberId Long memberId) {
+        memberUseCase.resetProfileImageToDefault(memberId);
+
+        return CommonResponse.of(CommonSuccessCode.SUCCESS);
+    }
 }

--- a/src/main/java/com/youthexpedition/azit/modules/member/adapter/in/web/docs/MemberControllerDocs.java
+++ b/src/main/java/com/youthexpedition/azit/modules/member/adapter/in/web/docs/MemberControllerDocs.java
@@ -240,4 +240,21 @@ public interface MemberControllerDocs {
             "UNAUTHORIZED", "EXPIRED_TOKEN", "INVALID_TOKEN", "TOKEN_REUSE_DETECTED", "BLACKLISTED_TOKEN"
     })
     CommonResponse<Void> updateProfileImage(@Parameter(hidden = true) @CurrentMemberId Long memberId, @Valid @RequestBody UpdateProfileImageRequest request);
+
+    @Operation(
+            summary = "프로필 이미지 기본 이미지로 변경",
+            description = """
+                    로그인한 사용자의 프로필 이미지를 기본 이미지로 초기화합니다. <br><br>
+
+                    **[참고 사항]** <br>
+                    * 기존에 업로드한 커스텀 이미지가 있는 경우 S3에서 삭제합니다. <br>
+                    * 기본 이미지 중 랜덤으로 1개를 선택하여 적용합니다. <br>
+                    * 이미 기본 이미지를 사용 중인 경우 S3 삭제 없이 다른 기본 이미지로 변경합니다.
+                    """
+    )
+    @ApiErrorCodeExamples({
+            "MEMBER_NOT_FOUND", "DEFAULT_IMAGE_NOT_FOUND",
+            "UNAUTHORIZED", "EXPIRED_TOKEN", "INVALID_TOKEN", "TOKEN_REUSE_DETECTED", "BLACKLISTED_TOKEN"
+    })
+    CommonResponse<Void> resetProfileImageToDefault(@Parameter(hidden = true) @CurrentMemberId Long memberId);
 }

--- a/src/main/java/com/youthexpedition/azit/modules/member/adapter/in/web/docs/MemberControllerDocs.java
+++ b/src/main/java/com/youthexpedition/azit/modules/member/adapter/in/web/docs/MemberControllerDocs.java
@@ -50,11 +50,11 @@ public interface MemberControllerDocs {
             서비스 이용을 중단하고 회원의 소셜 연동 해제 및 탈퇴 처리를 진행합니다. <br><br>
             
             **[참고 사항]** <br>
-            * 리더로 소속된 크루에 다른 멤버가 존재할 경우 탈퇴가 불가능합니다. (CANNOT_APP_WITHDRAW_AS_LEADER)
+            * 리더로 소속된 크루가 있을 경우 서비스 탈퇴가 불가합니다. 리더 권한 위임 또는 크루 해산이 필요합니다. (CANNOT_SERVICE_WITHDRAW_AS_LEADER)
             """
     )
     @ApiErrorCodeExamples({
-            "MEMBER_ALREADY_WITHDRAWN", "APPLE_REVOKE_FAILED",  "KAKAO_REVOKE_FAILED", "CANNOT_APP_WITHDRAW_AS_LEADER",
+            "MEMBER_ALREADY_WITHDRAWN", "APPLE_REVOKE_FAILED",  "KAKAO_REVOKE_FAILED", "CANNOT_SERVICE_WITHDRAW_AS_LEADER",
             "UNAUTHORIZED", "EXPIRED_TOKEN", "INVALID_TOKEN", "TOKEN_REUSE_DETECTED", "BLACKLISTED_TOKEN"
     })
     CommonResponse<Void> withdraw(@Parameter(hidden = true) @CurrentMemberId Long memberId, @Parameter(hidden = true) @CurrentAccessToken String accessToken);

--- a/src/main/java/com/youthexpedition/azit/modules/member/adapter/in/web/docs/MemberControllerDocs.java
+++ b/src/main/java/com/youthexpedition/azit/modules/member/adapter/in/web/docs/MemberControllerDocs.java
@@ -50,11 +50,11 @@ public interface MemberControllerDocs {
             서비스 이용을 중단하고 회원의 소셜 연동 해제 및 탈퇴 처리를 진행합니다. <br><br>
             
             **[참고 사항]** <br>
-            * 리더로 소속된 크루에 다른 멤버가 존재할 경우 탈퇴가 불가능합니다. (CANNOT_WITHDRAW_AS_LEADER)
+            * 리더로 소속된 크루에 다른 멤버가 존재할 경우 탈퇴가 불가능합니다. (CANNOT_APP_WITHDRAW_AS_LEADER)
             """
     )
     @ApiErrorCodeExamples({
-            "MEMBER_ALREADY_WITHDRAWN", "APPLE_REVOKE_FAILED",  "KAKAO_REVOKE_FAILED", "CANNOT_WITHDRAW_AS_LEADER",
+            "MEMBER_ALREADY_WITHDRAWN", "APPLE_REVOKE_FAILED",  "KAKAO_REVOKE_FAILED", "CANNOT_APP_WITHDRAW_AS_LEADER",
             "UNAUTHORIZED", "EXPIRED_TOKEN", "INVALID_TOKEN", "TOKEN_REUSE_DETECTED", "BLACKLISTED_TOKEN"
     })
     CommonResponse<Void> withdraw(@Parameter(hidden = true) @CurrentMemberId Long memberId, @Parameter(hidden = true) @CurrentAccessToken String accessToken);

--- a/src/main/java/com/youthexpedition/azit/modules/member/application/port/in/MemberUseCase.java
+++ b/src/main/java/com/youthexpedition/azit/modules/member/application/port/in/MemberUseCase.java
@@ -15,4 +15,5 @@ public interface MemberUseCase {
     MyInfoResponse getMyInfo(Long memberId);
     void updateNickname(Long memberId, UpdateNicknameCommand command);
     void updateProfileImage(Long memberId, UpdateProfileImageCommand command);
+    void resetProfileImageToDefault(Long memberId);
 }

--- a/src/main/java/com/youthexpedition/azit/modules/member/application/service/MemberService.java
+++ b/src/main/java/com/youthexpedition/azit/modules/member/application/service/MemberService.java
@@ -21,6 +21,7 @@ import com.youthexpedition.azit.modules.image.domain.model.enums.ImageUploadType
 import com.youthexpedition.azit.modules.member.application.port.in.command.AgreeToTermsCommand;
 import com.youthexpedition.azit.modules.member.application.port.in.command.UpdateNicknameCommand;
 import com.youthexpedition.azit.modules.member.application.port.in.command.UpdateProfileImageCommand;
+import com.youthexpedition.azit.modules.member.domain.model.provider.ProfileImageProvider;
 import com.youthexpedition.azit.modules.member.application.port.in.dto.MyInfoResponse;
 import com.youthexpedition.azit.modules.member.application.port.out.LoadMemberPort;
 import com.youthexpedition.azit.modules.member.application.port.out.SaveMemberPort;
@@ -52,6 +53,7 @@ public class MemberService implements MemberUseCase {
     private final MemberResponseMapper memberResponseMapper;
     private final ImageStoragePort imageStoragePort;
     private final ImageUrlFormatUtil imageUrlFormatUtil;
+    private final ProfileImageProvider profileImageProvider;
 
     private static final String BLACKLIST_REASON_WITHDRAWN = "withdrawn";
     private static final String DEFAULT_S3_PREFIX = "default/";
@@ -196,34 +198,6 @@ public class MemberService implements MemberUseCase {
         saveCrewMemberPort.saveAll(crewMembers);
     }
 
-    // 본인이 리더인 크루가 있으면 앱 탈퇴 불가
-    private void validateWithdrawal(Long memberId) {
-        // 사용자가 JOINED 상태이면서 리더인 크루 조회
-        List<CrewMember> crewMembersAsLeader = loadCrewMemberPort.findAllByMemberId(memberId).stream()
-                .filter(cm -> cm.getStatus() == CrewMemberStatus.JOINED)
-                .filter(cm -> cm.getRole() == CrewMemberRole.LEADER)
-                .toList();
-
-        if (crewMembersAsLeader.isEmpty()) return;
-
-        List<Long> crewIds = crewMembersAsLeader.stream()
-                .map(CrewMember::getCrewId)
-                .toList();
-
-        log.warn("[MEMBER] memberId: {}, 리더로서 가입되어 있는 크루(crewIds: {})가 있어 앱 탈퇴가 불가능합니다.", memberId, crewIds);
-        throw new BusinessException(CrewErrorCode.CANNOT_APP_WITHDRAW_AS_LEADER);
-    }
-
-    private void validateImageOwnership(String tempS3Key, Long memberId) {
-        Long imageOwnerMemberId = ImageUploadType.extractMemberIdFromTempKey(tempS3Key);
-        if (imageOwnerMemberId == null) {
-            throw new BusinessException(ImageErrorCode.IMAGE_NOT_UPLOADED);
-        }
-        if (!imageOwnerMemberId.equals(memberId)) {
-            throw new BusinessException(ImageErrorCode.IMAGE_OWNERSHIP_MISMATCH);
-        }
-    }
-
     @Override
     public void updateNickname(Long memberId, UpdateNicknameCommand command) {
         Member member = getMember(memberId);
@@ -257,5 +231,52 @@ public class MemberService implements MemberUseCase {
         // 상대 경로 저장
         member.updateProfileImageUrl("/" + finalS3Key);
         saveMemberPort.save(member);
+    }
+
+    @Override
+    public void resetProfileImageToDefault(Long memberId) {
+        Member member = getMember(memberId);
+
+        // 기존 이미지가 커스텀 업로드 이미지인 경우에만 S3에서 삭제
+        String oldS3Key = imageUrlFormatUtil.extractS3Key(member.getProfileImageUrl());
+        if (oldS3Key != null && !oldS3Key.startsWith(DEFAULT_S3_PREFIX)) {
+            imageStoragePort.delete(oldS3Key);
+        }
+
+        String defaultImageUrl = profileImageProvider.getRandomDefaultImage();
+        if (defaultImageUrl == null) {
+            throw new BusinessException(MemberErrorCode.DEFAULT_IMAGE_NOT_FOUND);
+        }
+
+        member.updateProfileImageUrl(defaultImageUrl);
+        saveMemberPort.save(member);
+    }
+
+    // 본인이 리더인 크루가 있으면 앱 탈퇴 불가
+    private void validateWithdrawal(Long memberId) {
+        // 사용자가 JOINED 상태이면서 리더인 크루 조회
+        List<CrewMember> crewMembersAsLeader = loadCrewMemberPort.findAllByMemberId(memberId).stream()
+                .filter(cm -> cm.getStatus() == CrewMemberStatus.JOINED)
+                .filter(cm -> cm.getRole() == CrewMemberRole.LEADER)
+                .toList();
+
+        if (crewMembersAsLeader.isEmpty()) return;
+
+        List<Long> crewIds = crewMembersAsLeader.stream()
+                .map(CrewMember::getCrewId)
+                .toList();
+
+        log.warn("[MEMBER] memberId: {}, 리더로서 가입되어 있는 크루(crewIds: {})가 있어 앱 탈퇴가 불가능합니다.", memberId, crewIds);
+        throw new BusinessException(CrewErrorCode.CANNOT_APP_WITHDRAW_AS_LEADER);
+    }
+
+    private void validateImageOwnership(String tempS3Key, Long memberId) {
+        Long imageOwnerMemberId = ImageUploadType.extractMemberIdFromTempKey(tempS3Key);
+        if (imageOwnerMemberId == null) {
+            throw new BusinessException(ImageErrorCode.IMAGE_NOT_UPLOADED);
+        }
+        if (!imageOwnerMemberId.equals(memberId)) {
+            throw new BusinessException(ImageErrorCode.IMAGE_OWNERSHIP_MISMATCH);
+        }
     }
 }

--- a/src/main/java/com/youthexpedition/azit/modules/member/application/service/MemberService.java
+++ b/src/main/java/com/youthexpedition/azit/modules/member/application/service/MemberService.java
@@ -33,6 +33,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Slf4j
@@ -190,11 +191,12 @@ public class MemberService implements MemberUseCase {
         }
 
         // 가입한 모든 크루 상태를 EXITED로 변경 및 저장
-        crewMembers.forEach(CrewMember::exit);
+        LocalDateTime now = LocalDateTime.now();
+        crewMembers.forEach(cm -> cm.exit(now));
         saveCrewMemberPort.saveAll(crewMembers);
     }
 
-    // 본인이 리더인 크루에 다른 멤버가 남아있는지 확인
+    // 본인이 리더인 크루가 있으면 앱 탈퇴 불가
     private void validateWithdrawal(Long memberId) {
         // 사용자가 JOINED 상태이면서 리더인 크루 조회
         List<CrewMember> crewMembersAsLeader = loadCrewMemberPort.findAllByMemberId(memberId).stream()
@@ -204,20 +206,12 @@ public class MemberService implements MemberUseCase {
 
         if (crewMembersAsLeader.isEmpty()) return;
 
-        // 리더로 속한 모든 크루 ID 가져오기
         List<Long> crewIds = crewMembersAsLeader.stream()
                 .map(CrewMember::getCrewId)
                 .toList();
 
-        List<Crew> crews = loadCrewPort.findAllByIds(crewIds);
-
-        // 크루 인원수가 1명보다 많으면 탈퇴 불가
-        for (Crew crew : crews) {
-            if (crew.getMemberCount() > 1) {
-                log.warn("[MEMBER] memberId: {}, 리더로서 가입되어 있는 크루(crewIds: {})에 멤버들이 남아 있어 탈퇴가 불가능합니다.", memberId, crewIds);
-                throw new BusinessException(CrewErrorCode.CANNOT_WITHDRAW_AS_LEADER);
-            }
-        }
+        log.warn("[MEMBER] memberId: {}, 리더로서 가입되어 있는 크루(crewIds: {})가 있어 앱 탈퇴가 불가능합니다.", memberId, crewIds);
+        throw new BusinessException(CrewErrorCode.CANNOT_APP_WITHDRAW_AS_LEADER);
     }
 
     private void validateImageOwnership(String tempS3Key, Long memberId) {

--- a/src/main/java/com/youthexpedition/azit/modules/member/domain/model/enums/MemberErrorCode.java
+++ b/src/main/java/com/youthexpedition/azit/modules/member/domain/model/enums/MemberErrorCode.java
@@ -14,7 +14,8 @@ public enum MemberErrorCode implements BaseErrorCode {
     MEMBER_ALREADY_WITHDRAWN("MEMBER_ALREADY_WITHDRAWN", "이미 탈퇴한 회원입니다.", HttpStatus.BAD_REQUEST),
     INVALID_MEMBER_STATUS("INVALID_MEMBER_STATUS", "유효하지 않은 회원 상태입니다.", HttpStatus.BAD_REQUEST),
     INSUFFICIENT_POINTS("INSUFFICIENT_POINTS", "포인트가 부족합니다.", HttpStatus.BAD_REQUEST),
-    INVALID_POINT_VALUE("INVALID_POINT_VALUE", "유효하지 않은 포인트 요청입니다.", HttpStatus.BAD_REQUEST);
+    INVALID_POINT_VALUE("INVALID_POINT_VALUE", "유효하지 않은 포인트 요청입니다.", HttpStatus.BAD_REQUEST),
+    DEFAULT_IMAGE_NOT_FOUND("DEFAULT_IMAGE_NOT_FOUND", "기본 이미지를 찾을 수 없습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
 
     private final String code;
     private final String message;


### PR DESCRIPTION
## 📌 관련 이슈
- closes #118

## ✨ 작업 내용
> 이번 PR에서 변경된 핵심 내용을 요약해주세요.

- 크루 탈퇴 API 구현
- 크루 방출/탈퇴 후 24시간 재가입 불가 로직 구현
- 서비스 탈퇴 시 리더인 크루가 존재할 경우 탈퇴 불가 로직 구현
- 프로필 이미지 기본 이미지로 변경 API 구현
- 방출 계정 마스킹 미처리로 변경

## 🧱 아키텍처 변경 요약
> 이번 작업으로 인해 변경된 주요 흐름을 적어주세요. (없으면 생략 가능)

- 예: 신규 UseCase 추가 및 외부 API 연동 어댑터 구현

## 📸 스크린샷 (선택 사항)
> API 테스트 결과 등을 첨부해주세요.
<img width="997" height="420" alt="image" src="https://github.com/user-attachments/assets/1c6e68fa-227c-4e63-ac88-6493d4fa16bd" />


## ⚠️ 주의 사항 (선택)
- [x] DB 스키마 변경이 있나요?
- [x] API 명세(Swagger)가 업데이트 되었나요?
- [ ] 새로운 환경 변수(.env)가 추가 되었나요?

## ✅ 셀프 체크리스트
- [ ] 브랜치 전략(develop)에 맞게 올렸나요?
- [ ] 커밋 컨벤션을 준수했나요?
- [ ] 불필요한 주석이나 print문은 제거했나요?
- [ ] 로컬에서 테스트는 성공했나요?