### PR TITLE
[FEAT] 토큰 재발급 시 기존 토큰에 유예기간 설정

### DIFF
--- a/src/main/java/com/youthexpedition/azit/infrastructure/auth/util/CookieUtil.java
+++ b/src/main/java/com/youthexpedition/azit/infrastructure/auth/util/CookieUtil.java
@@ -19,11 +19,15 @@ import lombok.extern.slf4j.Slf4j;
 public class CookieUtil {
 
     private final boolean secure;
+    private final String sameSite;
     private final JwtProvider jwtProvider;
 
-    public CookieUtil(JwtProvider jwtProvider, @Value("${jwt.cookie.secure}") boolean secure) {
+    public CookieUtil(JwtProvider jwtProvider,
+                      @Value("${jwt.cookie.secure}") boolean secure,
+                      @Value("${jwt.cookie.same-site}") String sameSite) {
         this.jwtProvider = jwtProvider;
         this.secure = secure;
+        this.sameSite = sameSite;
     }
 
     /**
@@ -42,7 +46,7 @@ public class CookieUtil {
                 .path("/")
                 .httpOnly(true)
                 .secure(secure) // 운영 환경에서는 HTTPS가 필수이므로 true 설정
-                .sameSite("None")
+                .sameSite(sameSite)
                 .maxAge(maxAgeSeconds)
                 .build();
     }

--- a/src/main/java/com/youthexpedition/azit/modules/auth/adapter/out/persistence/RedisTokenAdapter.java
+++ b/src/main/java/com/youthexpedition/azit/modules/auth/adapter/out/persistence/RedisTokenAdapter.java
@@ -16,6 +16,7 @@ public class RedisTokenAdapter implements TokenPort {
     private final TokenProviderPort tokenProviderPort;
 
     private static final String REFRESH_TOKEN_PREFIX = "RT:";
+    private static final String PREV_TOKEN_PREFIX = "RT_PREV:";
     private static final String BLACKLIST_PREFIX = "BL:";
 
     @Override
@@ -32,6 +33,16 @@ public class RedisTokenAdapter implements TokenPort {
     @Override
     public void deleteByMemberId(Long memberId) {
         redisTemplate.delete(REFRESH_TOKEN_PREFIX + memberId);
+    }
+
+    @Override
+    public void savePrevToken(Long memberId, String prevToken, long ttlSeconds) { // race condition 시 로그아웃 방어하기 위해 10초 동안 임시 저장
+        redisTemplate.opsForValue().set(PREV_TOKEN_PREFIX + memberId, prevToken, ttlSeconds, TimeUnit.SECONDS);
+    }
+
+    @Override
+    public Optional<String> findPrevToken(Long memberId) {
+        return Optional.ofNullable(redisTemplate.opsForValue().get(PREV_TOKEN_PREFIX + memberId));
     }
 
     @Override

--- a/src/main/java/com/youthexpedition/azit/modules/auth/application/port/out/TokenPort.java
+++ b/src/main/java/com/youthexpedition/azit/modules/auth/application/port/out/TokenPort.java
@@ -8,4 +8,6 @@ public interface TokenPort {
     void deleteByMemberId(Long memberId);
     void addToBlacklist(String accessToken, String reason);
     boolean isBlacklisted(String accessToken);
+    void savePrevToken(Long memberId, String prevToken, long ttlSeconds);
+    Optional<String> findPrevToken(Long memberId);
 }

--- a/src/main/java/com/youthexpedition/azit/modules/auth/application/service/TokenManagementService.java
+++ b/src/main/java/com/youthexpedition/azit/modules/auth/application/service/TokenManagementService.java
@@ -12,22 +12,36 @@ import com.youthexpedition.azit.modules.crew.domain.model.CrewMember;
 import com.youthexpedition.azit.modules.member.application.port.out.LoadMemberPort;
 import com.youthexpedition.azit.modules.member.domain.model.Member;
 import com.youthexpedition.azit.modules.member.domain.model.enums.MemberErrorCode;
-import lombok.RequiredArgsConstructor;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
-@RequiredArgsConstructor
 @Transactional
 public class TokenManagementService implements TokenUseCase {
     private final LoadMemberPort loadMemberPort;
     private final TokenPort tokenPort;
     private final TokenProviderPort tokenProviderPort;
     private final LoadCrewMemberPort loadCrewMemberPort;
+    private final Counter raceConditionCounter;
 
     private static final String BLACKLIST_REASON_LOGOUT = "logout";
+    private static final long PREV_TOKEN_TTL_SECONDS = 10;
+
+    public TokenManagementService(LoadMemberPort loadMemberPort, TokenPort tokenPort,
+                                  TokenProviderPort tokenProviderPort, LoadCrewMemberPort loadCrewMemberPort,
+                                  MeterRegistry meterRegistry) {
+        this.loadMemberPort = loadMemberPort;
+        this.tokenPort = tokenPort;
+        this.tokenProviderPort = tokenProviderPort;
+        this.loadCrewMemberPort = loadCrewMemberPort;
+        this.raceConditionCounter = Counter.builder("auth.token.race_condition")
+                .description("RTR 재발급 중 race condition 발생 횟수")
+                .register(meterRegistry);
+    }
 
     @Override
     public AuthResult reissue(String refreshToken) {
@@ -42,28 +56,43 @@ public class TokenManagementService implements TokenUseCase {
                 .orElseThrow(() -> new BusinessException(AuthErrorCode.TOKEN_REUSE_DETECTED));
 
         if (!savedRT.equals(refreshToken)) {
-            tokenPort.deleteByMemberId(memberId);
+            // 10초 내 재요청(race condition)인지 확인
+            boolean isGracePeriod = tokenPort.findPrevToken(memberId)
+                    .map(prev -> prev.equals(refreshToken))
+                    .orElse(false);
 
-            log.warn("[TOKEN_MANAGEMENT] memberId: {} 의 비정상적인 토큰 접근(탈취 의심)이 감지되어 모든 세션을 강제 종료합니다.", memberId);
-            throw new BusinessException(AuthErrorCode.TOKEN_REUSE_DETECTED);
+            if (!isGracePeriod) {
+                tokenPort.deleteByMemberId(memberId);
+                log.warn("[TOKEN_MANAGEMENT] memberId: {} 의 비정상적인 토큰 접근(탈취 의심)이 감지되어 모든 세션을 강제 종료합니다.", memberId);
+                throw new BusinessException(AuthErrorCode.TOKEN_REUSE_DETECTED);
+            }
+
+            // Race condition: 이미 교체된 savedRT(RT2)를 그대로 사용하고 AT만 새로 발급
+            log.info("[TOKEN_MANAGEMENT] memberId: {} 에서 race condition 이 발생했습니다.", memberId);
+            raceConditionCounter.increment();
+            Member member = loadMemberPort.findById(memberId)
+                    .orElseThrow(() -> new BusinessException(MemberErrorCode.MEMBER_NOT_FOUND));
+
+            String newAccessToken = tokenProviderPort.generateAccessToken(member.getId(), member.getRole(), member.getStatus());
+            AuthToken token = AuthToken.builder()
+                    .accessToken(newAccessToken)
+                    .refreshToken(savedRT)
+                    .accessTokenExpiresIn(tokenProviderPort.getAccessTokenExpirationSeconds())
+                    .build();
+
+            Long crewId = resolveCrewId(member);
+            return new AuthResult(token, member.getStatus(), crewId);
         }
 
-        // 신규 토큰 발급 및 Redis 업데이트
+        // 정상 경로: 신규 토큰 발급 및 Redis 업데이트
         Member member = loadMemberPort.findById(memberId)
                 .orElseThrow(() -> new BusinessException(MemberErrorCode.MEMBER_NOT_FOUND));
 
         String newAccessToken = tokenProviderPort.generateAccessToken(member.getId(), member.getRole(), member.getStatus());
         String newRefreshToken = tokenProviderPort.generateRefreshToken(member.getId());
 
+        tokenPort.savePrevToken(memberId, refreshToken, PREV_TOKEN_TTL_SECONDS); // 직전 RT 보관 (10초)
         tokenPort.save(member.getId(), newRefreshToken, tokenProviderPort.getRefreshTokenExpirationSeconds());
-
-        Long crewId = null;
-        // 크루 ID 필요한지 체크 후 가장 최근에 가입한 크루 조회
-        if (member.getStatus().isCrewInfoRequired()) {
-            crewId = loadCrewMemberPort.findRecentJoinedCrewMember(member.getId())
-                    .map(CrewMember::getCrewId)
-                    .orElse(null);
-        }
 
         AuthToken token = AuthToken.builder()
                 .accessToken(newAccessToken)
@@ -71,7 +100,15 @@ public class TokenManagementService implements TokenUseCase {
                 .accessTokenExpiresIn(tokenProviderPort.getAccessTokenExpirationSeconds())
                 .build();
 
+        Long crewId = resolveCrewId(member);
         return new AuthResult(token, member.getStatus(), crewId);
+    }
+
+    private Long resolveCrewId(Member member) {
+        if (!member.getStatus().isCrewInfoRequired()) return null;
+        return loadCrewMemberPort.findRecentJoinedCrewMember(member.getId())
+                .map(CrewMember::getCrewId)
+                .orElse(null);
     }
 
     @Override

--- a/src/main/java/com/youthexpedition/azit/modules/auth/application/service/TokenManagementService.java
+++ b/src/main/java/com/youthexpedition/azit/modules/auth/application/service/TokenManagementService.java
@@ -12,36 +12,23 @@ import com.youthexpedition.azit.modules.crew.domain.model.CrewMember;
 import com.youthexpedition.azit.modules.member.application.port.out.LoadMemberPort;
 import com.youthexpedition.azit.modules.member.domain.model.Member;
 import com.youthexpedition.azit.modules.member.domain.model.enums.MemberErrorCode;
-import io.micrometer.core.instrument.Counter;
-import io.micrometer.core.instrument.MeterRegistry;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
+@RequiredArgsConstructor
 @Transactional
 public class TokenManagementService implements TokenUseCase {
     private final LoadMemberPort loadMemberPort;
     private final TokenPort tokenPort;
     private final TokenProviderPort tokenProviderPort;
     private final LoadCrewMemberPort loadCrewMemberPort;
-    private final Counter raceConditionCounter;
 
     private static final String BLACKLIST_REASON_LOGOUT = "logout";
     private static final long PREV_TOKEN_TTL_SECONDS = 10;
-
-    public TokenManagementService(LoadMemberPort loadMemberPort, TokenPort tokenPort,
-                                  TokenProviderPort tokenProviderPort, LoadCrewMemberPort loadCrewMemberPort,
-                                  MeterRegistry meterRegistry) {
-        this.loadMemberPort = loadMemberPort;
-        this.tokenPort = tokenPort;
-        this.tokenProviderPort = tokenProviderPort;
-        this.loadCrewMemberPort = loadCrewMemberPort;
-        this.raceConditionCounter = Counter.builder("auth.token.race_condition")
-                .description("RTR 재발급 중 race condition 발생 횟수")
-                .register(meterRegistry);
-    }
 
     @Override
     public AuthResult reissue(String refreshToken) {
@@ -69,7 +56,6 @@ public class TokenManagementService implements TokenUseCase {
 
             // Race condition: 이미 교체된 savedRT(RT2)를 그대로 사용하고 AT만 새로 발급
             log.info("[TOKEN_MANAGEMENT] memberId: {} 에서 race condition 이 발생했습니다.", memberId);
-            raceConditionCounter.increment();
             Member member = loadMemberPort.findById(memberId)
                     .orElseThrow(() -> new BusinessException(MemberErrorCode.MEMBER_NOT_FOUND));
 

--- a/src/main/java/com/youthexpedition/azit/modules/auth/application/service/TokenManagementService.java
+++ b/src/main/java/com/youthexpedition/azit/modules/auth/application/service/TokenManagementService.java
@@ -42,6 +42,9 @@ public class TokenManagementService implements TokenUseCase {
         String savedRT = tokenPort.findByMemberId(memberId)
                 .orElseThrow(() -> new BusinessException(AuthErrorCode.TOKEN_REUSE_DETECTED));
 
+        Member member = loadMemberPort.findById(memberId)
+                .orElseThrow(() -> new BusinessException(MemberErrorCode.MEMBER_NOT_FOUND));
+
         if (!savedRT.equals(refreshToken)) {
             // 10초 내 재요청(race condition)인지 확인
             boolean isGracePeriod = tokenPort.findPrevToken(memberId)
@@ -56,8 +59,6 @@ public class TokenManagementService implements TokenUseCase {
 
             // Race condition: 이미 교체된 savedRT(RT2)를 그대로 사용하고 AT만 새로 발급
             log.info("[TOKEN_MANAGEMENT] memberId: {} 에서 race condition 이 발생했습니다.", memberId);
-            Member member = loadMemberPort.findById(memberId)
-                    .orElseThrow(() -> new BusinessException(MemberErrorCode.MEMBER_NOT_FOUND));
 
             String newAccessToken = tokenProviderPort.generateAccessToken(member.getId(), member.getRole(), member.getStatus());
             AuthToken token = AuthToken.builder()
@@ -71,9 +72,6 @@ public class TokenManagementService implements TokenUseCase {
         }
 
         // 정상 경로: 신규 토큰 발급 및 Redis 업데이트
-        Member member = loadMemberPort.findById(memberId)
-                .orElseThrow(() -> new BusinessException(MemberErrorCode.MEMBER_NOT_FOUND));
-
         String newAccessToken = tokenProviderPort.generateAccessToken(member.getId(), member.getRole(), member.getStatus());
         String newRefreshToken = tokenProviderPort.generateRefreshToken(member.getId());
 

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -72,6 +72,7 @@ jwt:
   refresh-token-name: azit_rt_dev
   cookie:
     secure: true
+    same-site: None
 
 payment:
   bank:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -69,6 +69,7 @@ jwt:
   refresh-token-name: azit_rt_prod
   cookie:
     secure: true
+    same-site: Lax
 
 payment:
   bank:


### PR DESCRIPTION
## 📌 관련 이슈
- closes #161 

## ✨ 작업 내용
> 이번 PR에서 변경된 핵심 내용을 요약해주세요.

- rtr 시 간헐적으로 race condition 으로 인한 로그아웃 방지를 위해 기존 토큰 유예기간 10초 설정
- 쿠키 sameSite 환경변수로 설정하도록 수정

## 🧱 아키텍처 변경 요약
> 이번 작업으로 인해 변경된 주요 흐름을 적어주세요. (없으면 생략 가능)

- 예: 신규 UseCase 추가 및 외부 API 연동 어댑터 구현

## 📸 스크린샷 (선택 사항)
> API 테스트 결과 등을 첨부해주세요.
<img width="182" height="42" alt="image" src="https://github.com/user-attachments/assets/f1d4318e-8a02-40b3-ba49-f34c154f4e3c" />


## ⚠️ 주의 사항 (선택)
- [ ] DB 스키마 변경이 있나요?
- [ ] API 명세(Swagger)가 업데이트 되었나요?
- [ ] 새로운 환경 변수(.env)가 추가 되었나요?

## ✅ 셀프 체크리스트
- [ ] 브랜치 전략(develop)에 맞게 올렸나요?
- [ ] 커밋 컨벤션을 준수했나요?
- [ ] 불필요한 주석이나 print문은 제거했나요?
- [ ] 로컬에서 테스트는 성공했나요?