### PR TITLE
[FEAT] 크루 이미지 업로드 API 구현

### DIFF
--- a/src/main/java/com/youthexpedition/azit/infrastructure/config/swagger/ApiErrorCodeExampleCustomizer.java
+++ b/src/main/java/com/youthexpedition/azit/infrastructure/config/swagger/ApiErrorCodeExampleCustomizer.java
@@ -5,6 +5,7 @@ import com.youthexpedition.azit.infrastructure.common.response.code.BaseErrorCod
 import com.youthexpedition.azit.infrastructure.common.response.code.CommonErrorCode;
 import com.youthexpedition.azit.modules.auth.domain.model.enums.AuthErrorCode;
 import com.youthexpedition.azit.modules.crew.domain.model.enums.CrewErrorCode;
+import com.youthexpedition.azit.modules.image.domain.model.enums.ImageErrorCode;
 import com.youthexpedition.azit.modules.member.domain.model.enums.DeliveryAddressErrorCode;
 import com.youthexpedition.azit.modules.member.domain.model.enums.MemberErrorCode;
 import com.youthexpedition.azit.modules.store.domain.model.enums.StoreErrorCode;
@@ -43,7 +44,8 @@ public class ApiErrorCodeExampleCustomizer implements OperationCustomizer {
 
         // 검색 대상이 될 도메인별 에러 Enum 리스트
         List<Class<? extends BaseErrorCode>> errorCodeEnums = List.of(
-                 MemberErrorCode.class, AuthErrorCode.class, CrewErrorCode.class, StoreErrorCode.class, DeliveryAddressErrorCode.class
+                 MemberErrorCode.class, AuthErrorCode.class, CrewErrorCode.class, StoreErrorCode.class, DeliveryAddressErrorCode.class,
+                ImageErrorCode.class
         );
 
         // 어노테이션에 명시된 에러 코드들을 찾아서 추가

--- a/src/main/java/com/youthexpedition/azit/modules/crew/adapter/in/web/CrewController.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/adapter/in/web/CrewController.java
@@ -7,6 +7,7 @@ import com.youthexpedition.azit.infrastructure.common.response.code.CommonSucces
 import com.youthexpedition.azit.modules.crew.adapter.in.web.docs.CrewControllerDocs;
 import com.youthexpedition.azit.modules.crew.adapter.in.web.dto.CreateCrewRequest;
 import com.youthexpedition.azit.modules.crew.adapter.in.web.dto.JoinCrewRequest;
+import com.youthexpedition.azit.modules.crew.adapter.in.web.dto.UpdateCrewImageRequest;
 import com.youthexpedition.azit.modules.crew.application.port.in.CrewUseCase;
 import com.youthexpedition.azit.modules.crew.application.port.in.command.ProcessJoinCommand;
 import com.youthexpedition.azit.modules.crew.application.port.in.dto.*;
@@ -99,5 +100,12 @@ public class CrewController implements CrewControllerDocs {
         InvitationCodeResponse response = crewUseCase.regenerateInvitationCode(crewId, memberId);
 
         return CommonResponse.of(CommonSuccessCode.SUCCESS, response);
+    }
+
+    @PatchMapping("/{crewId}/image")
+    public CommonResponse<Void> updateCrewImage(@PathVariable Long crewId, @CurrentMemberId Long memberId, @Valid @RequestBody UpdateCrewImageRequest request) {
+        crewUseCase.updateCrewImage(crewId, memberId, request.toCommand());
+
+        return CommonResponse.of(CommonSuccessCode.SUCCESS);
     }
 }

--- a/src/main/java/com/youthexpedition/azit/modules/crew/adapter/in/web/docs/CrewControllerDocs.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/adapter/in/web/docs/CrewControllerDocs.java
@@ -6,6 +6,7 @@ import com.youthexpedition.azit.infrastructure.common.response.CommonResponse;
 import com.youthexpedition.azit.infrastructure.config.swagger.ApiErrorCodeExamples;
 import com.youthexpedition.azit.modules.crew.adapter.in.web.dto.CreateCrewRequest;
 import com.youthexpedition.azit.modules.crew.adapter.in.web.dto.JoinCrewRequest;
+import com.youthexpedition.azit.modules.crew.adapter.in.web.dto.UpdateCrewImageRequest;
 import com.youthexpedition.azit.modules.crew.application.port.in.dto.*;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -200,4 +201,28 @@ public interface CrewControllerDocs {
     })
     CommonResponse<InvitationCodeResponse> regenerateInvitationCode(
             @PathVariable Long crewId, @Parameter(hidden = true) @CurrentMemberId Long memberId);
+
+    @Operation(
+            summary = "크루 이미지 수정",
+            description = """
+                    크루 이미지를 수정합니다. <br><br>
+
+                    **[사전 조건]** <br>
+                    * POST /api/v1/images/presigned-url API에 type: CREW_IMAGE, crewId를 전달하여 Presigned URL을 발급받은 뒤, S3에 이미지를 **실제로 업로드한 후** 호출해야 합니다. <br><br>
+
+                    **[제약 사항]** <br>
+                    * 리더만 크루 이미지를 수정할 수 있습니다. (NOT_CREW_LEADER) <br>
+                    * 업로드되지 않은 이미지 URL을 전달하면 IMAGE_NOT_UPLOADED 오류가 반환됩니다. <br>
+                    * presigned URL 발급 시 사용한 crewId와 요청 경로의 crewId가 일치해야 합니다. (IMAGE_OWNERSHIP_MISMATCH)
+                    """
+    )
+    @ApiErrorCodeExamples({
+            "CREW_NOT_FOUND", "NOT_A_CREW_MEMBER", "NOT_CREW_LEADER",
+            "IMAGE_NOT_UPLOADED", "IMAGE_OWNERSHIP_MISMATCH",
+            "UNAUTHORIZED", "EXPIRED_TOKEN", "INVALID_TOKEN", "TOKEN_REUSE_DETECTED", "BLACKLISTED_TOKEN"
+    })
+    CommonResponse<Void> updateCrewImage(
+            @PathVariable Long crewId,
+            @Parameter(hidden = true) @CurrentMemberId Long memberId,
+            @Valid @RequestBody UpdateCrewImageRequest request);
 }

--- a/src/main/java/com/youthexpedition/azit/modules/crew/adapter/in/web/dto/UpdateCrewImageRequest.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/adapter/in/web/dto/UpdateCrewImageRequest.java
@@ -1,0 +1,16 @@
+package com.youthexpedition.azit.modules.crew.adapter.in.web.dto;
+
+import com.youthexpedition.azit.modules.crew.application.port.in.command.UpdateCrewImageCommand;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+public record UpdateCrewImageRequest(
+        @Schema(description = "업로드 완료된 이미지의 CloudFront URL", requiredMode = Schema.RequiredMode.REQUIRED,
+                example = "https://azitcrew.com/temp/crew/1/2026-04-21_550e8400.jpg")
+        @NotBlank(message = "이미지 URL은 필수입니다.")
+        String imageUrl
+) {
+    public UpdateCrewImageCommand toCommand() {
+        return UpdateCrewImageCommand.of(imageUrl);
+    }
+}

--- a/src/main/java/com/youthexpedition/azit/modules/crew/application/port/in/CrewUseCase.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/application/port/in/CrewUseCase.java
@@ -4,6 +4,7 @@ import com.youthexpedition.azit.infrastructure.common.query.CursorPageQuery;
 import com.youthexpedition.azit.modules.crew.application.port.in.command.CreateCrewCommand;
 import com.youthexpedition.azit.modules.crew.application.port.in.command.JoinCrewCommand;
 import com.youthexpedition.azit.modules.crew.application.port.in.command.ProcessJoinCommand;
+import com.youthexpedition.azit.modules.crew.application.port.in.command.UpdateCrewImageCommand;
 import com.youthexpedition.azit.modules.crew.application.port.in.dto.*;
 
 import java.util.List;
@@ -20,4 +21,5 @@ public interface CrewUseCase {
     void expelCrewMember(Long crewId, Long leaderId, Long targetMemberId);
     void exitCrew(Long crewId, Long memberId);
     InvitationCodeResponse regenerateInvitationCode(Long crewId, Long memberId);
+    void updateCrewImage(Long crewId, Long memberId, UpdateCrewImageCommand command);
 }

--- a/src/main/java/com/youthexpedition/azit/modules/crew/application/port/in/command/UpdateCrewImageCommand.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/application/port/in/command/UpdateCrewImageCommand.java
@@ -1,0 +1,9 @@
+package com.youthexpedition.azit.modules.crew.application.port.in.command;
+
+public record UpdateCrewImageCommand(
+        String imageUrl
+) {
+    public static UpdateCrewImageCommand of(String imageUrl) {
+        return new UpdateCrewImageCommand(imageUrl);
+    }
+}

--- a/src/main/java/com/youthexpedition/azit/modules/crew/application/service/CrewService.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/application/service/CrewService.java
@@ -398,7 +398,7 @@ public class CrewService implements CrewUseCase {
         }
 
         // temp 경로의 crewId가 요청 crewId와 일치하는지 검증
-        Long pathCrewId = ImageUploadType.extractMemberIdFromTempKey(tempS3Key);
+        Long pathCrewId = ImageUploadType.extractEntityIdFromTempKey(tempS3Key);
         if (!crewId.equals(pathCrewId)) {
             throw new BusinessException(ImageErrorCode.IMAGE_OWNERSHIP_MISMATCH);
         }

--- a/src/main/java/com/youthexpedition/azit/modules/crew/application/service/CrewService.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/application/service/CrewService.java
@@ -5,9 +5,14 @@ import com.youthexpedition.azit.infrastructure.common.response.SliceResponse;
 import com.youthexpedition.azit.infrastructure.exception.BusinessException;
 import com.youthexpedition.azit.modules.crew.application.port.in.CrewScheduleUseCase;
 import com.youthexpedition.azit.modules.crew.application.port.in.CrewUseCase;
+import com.youthexpedition.azit.infrastructure.common.util.ImageUrlFormatUtil;
 import com.youthexpedition.azit.modules.crew.application.port.in.command.CreateCrewCommand;
 import com.youthexpedition.azit.modules.crew.application.port.in.command.JoinCrewCommand;
 import com.youthexpedition.azit.modules.crew.application.port.in.command.ProcessJoinCommand;
+import com.youthexpedition.azit.modules.crew.application.port.in.command.UpdateCrewImageCommand;
+import com.youthexpedition.azit.modules.image.application.port.out.ImageStoragePort;
+import com.youthexpedition.azit.modules.image.domain.model.enums.ImageErrorCode;
+import com.youthexpedition.azit.modules.image.domain.model.enums.ImageUploadType;
 import com.youthexpedition.azit.modules.crew.application.port.in.dto.*;
 import com.youthexpedition.azit.modules.crew.application.port.out.LoadCrewMemberPort;
 import com.youthexpedition.azit.modules.crew.application.port.out.LoadCrewPort;
@@ -53,6 +58,10 @@ public class CrewService implements CrewUseCase {
     private final CrewMemberResponseMapper crewMemberResponseMapper;
     private final CrewResponseMapper crewResponseMapper;
     private final CrewImageProvider crewImageProvider;
+    private final ImageStoragePort imageStoragePort;
+    private final ImageUrlFormatUtil imageUrlFormatUtil;
+
+    private static final String DEFAULT_S3_PREFIX = "default/";
 
     @Override
     @Retryable(
@@ -375,6 +384,41 @@ public class CrewService implements CrewUseCase {
         saveCrewPort.save(crew);
 
         return InvitationCodeResponse.of(newCode);
+    }
+
+    @Override
+    public void updateCrewImage(Long crewId, Long memberId, UpdateCrewImageCommand command) {
+        // 리더 권한 검증
+        validateLeader(crewId, memberId);
+
+        // temp 경로 파일 존재 여부 검증
+        String tempS3Key = imageUrlFormatUtil.extractS3Key(command.imageUrl());
+        if (tempS3Key == null || !tempS3Key.startsWith(ImageUploadType.TEMP_PREFIX) || !imageStoragePort.exists(tempS3Key)) {
+            throw new BusinessException(ImageErrorCode.IMAGE_NOT_UPLOADED);
+        }
+
+        // temp 경로의 crewId가 요청 crewId와 일치하는지 검증
+        Long pathCrewId = ImageUploadType.extractMemberIdFromTempKey(tempS3Key);
+        if (!crewId.equals(pathCrewId)) {
+            throw new BusinessException(ImageErrorCode.IMAGE_OWNERSHIP_MISMATCH);
+        }
+
+        Crew crew = loadCrewPort.findById(crewId)
+                .orElseThrow(() -> new BusinessException(CrewErrorCode.CREW_NOT_FOUND));
+
+        // 기존 이미지가 커스텀 업로드 이미지인 경우에만 S3에서 삭제
+        String oldS3Key = imageUrlFormatUtil.extractS3Key(crew.getImageUrl());
+        if (oldS3Key != null && !oldS3Key.startsWith(DEFAULT_S3_PREFIX)) {
+            imageStoragePort.delete(oldS3Key);
+        }
+
+        // temp → 실제 경로로 이동
+        String finalS3Key = tempS3Key.substring(ImageUploadType.TEMP_PREFIX.length());
+        imageStoragePort.move(tempS3Key, finalS3Key);
+
+        // 상대 경로 저장
+        crew.updateImageUrl("/" + finalS3Key);
+        saveCrewPort.save(crew);
     }
 
     // 리더 여부 체크

--- a/src/main/java/com/youthexpedition/azit/modules/crew/domain/model/Crew.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/domain/model/Crew.java
@@ -69,4 +69,8 @@ public class Crew {
     public void updateInvitationCode(String invitationCode) {
         this.invitationCode = invitationCode;
     }
+
+    public void updateImageUrl(String imageUrl) {
+        this.imageUrl = imageUrl;
+    }
 }

--- a/src/main/java/com/youthexpedition/azit/modules/image/adapter/in/web/docs/ImageControllerDocs.java
+++ b/src/main/java/com/youthexpedition/azit/modules/image/adapter/in/web/docs/ImageControllerDocs.java
@@ -35,7 +35,7 @@ public interface ImageControllerDocs {
                     """
     )
     @ApiErrorCodeExamples({
-            "UNSUPPORTED_FILE_EXTENSION", "INVALID_FILE_NAME",
+            "UNSUPPORTED_FILE_EXTENSION", "INVALID_FILE_NAME", "CREW_ID_REQUIRED",
             "UNAUTHORIZED", "EXPIRED_TOKEN", "INVALID_TOKEN", "TOKEN_REUSE_DETECTED", "BLACKLISTED_TOKEN"
     })
     CommonResponse<PresignedUrlResponse> generatePresignedUrl(

--- a/src/main/java/com/youthexpedition/azit/modules/image/adapter/in/web/docs/ImageControllerDocs.java
+++ b/src/main/java/com/youthexpedition/azit/modules/image/adapter/in/web/docs/ImageControllerDocs.java
@@ -25,7 +25,8 @@ public interface ImageControllerDocs {
                     3. 업로드 완료 후 imageUrl으로 프로필 수정 / 크루 이미지 수정 등 관련 API를 호출합니다. <br><br>
 
                     **[업로드 타입]** <br>
-                    * MEMBER_PROFILE : 프로필 이미지 <br><br>
+                    * MEMBER_PROFILE : 멤버 프로필 이미지 (crewId 불필요) <br>
+                    * CREW_IMAGE : 크루 이미지 (crewId 필수) <br><br>
 
                     **[제약 사항]** <br>
                     * 허용 확장자: jpg, jpeg, png, webp (그 외: UNSUPPORTED_FILE_EXTENSION) <br>

--- a/src/main/java/com/youthexpedition/azit/modules/image/adapter/in/web/dto/PresignedUrlRequest.java
+++ b/src/main/java/com/youthexpedition/azit/modules/image/adapter/in/web/dto/PresignedUrlRequest.java
@@ -7,16 +7,19 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
 public record PresignedUrlRequest(
-        @Schema(description = "이미지 업로드 타입", requiredMode = Schema.RequiredMode.REQUIRED, allowableValues = {"MEMBER_PROFILE"})
+        @Schema(description = "이미지 업로드 타입", requiredMode = Schema.RequiredMode.REQUIRED, allowableValues = {"MEMBER_PROFILE", "CREW_IMAGE"})
         @NotNull(message = "이미지 업로드 타입은 필수입니다.")
         ImageUploadType type,
 
         @Schema(description = "업로드할 파일명 (확장자 포함)", requiredMode = Schema.RequiredMode.REQUIRED,
                 example = "photo.jpg")
         @NotBlank(message = "파일명은 필수입니다.")
-        String fileName
+        String fileName,
+
+        @Schema(description = "크루 ID (type이 CREW_IMAGE일 때 필수)", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+        Long crewId
 ) {
     public GeneratePresignedUrlCommand toCommand(Long memberId) {
-        return GeneratePresignedUrlCommand.of(type, fileName, memberId);
+        return GeneratePresignedUrlCommand.of(type, fileName, memberId, crewId);
     }
 }

--- a/src/main/java/com/youthexpedition/azit/modules/image/application/port/in/command/GeneratePresignedUrlCommand.java
+++ b/src/main/java/com/youthexpedition/azit/modules/image/application/port/in/command/GeneratePresignedUrlCommand.java
@@ -5,9 +5,10 @@ import com.youthexpedition.azit.modules.image.domain.model.enums.ImageUploadType
 public record GeneratePresignedUrlCommand(
         ImageUploadType type,
         String fileName,
-        Long memberId
+        Long memberId,
+        Long crewId
 ) {
-    public static GeneratePresignedUrlCommand of(ImageUploadType type, String fileName, Long memberId) {
-        return new GeneratePresignedUrlCommand(type, fileName, memberId);
+    public static GeneratePresignedUrlCommand of(ImageUploadType type, String fileName, Long memberId, Long crewId) {
+        return new GeneratePresignedUrlCommand(type, fileName, memberId, crewId);
     }
 }

--- a/src/main/java/com/youthexpedition/azit/modules/image/application/service/ImageService.java
+++ b/src/main/java/com/youthexpedition/azit/modules/image/application/service/ImageService.java
@@ -28,6 +28,10 @@ public class ImageService implements ImageUseCase {
 
     @Override
     public PresignedUrlResponse generatePresignedUrl(GeneratePresignedUrlCommand command) {
+        if (command.type() == ImageUploadType.CREW_IMAGE && command.crewId() == null) {
+            throw new BusinessException(ImageErrorCode.CREW_ID_REQUIRED);
+        }
+
         String extension = extractExtension(command.fileName());
         validateExtension(extension);
 

--- a/src/main/java/com/youthexpedition/azit/modules/image/application/service/ImageService.java
+++ b/src/main/java/com/youthexpedition/azit/modules/image/application/service/ImageService.java
@@ -42,7 +42,8 @@ public class ImageService implements ImageUseCase {
 
     private String buildS3Key(GeneratePresignedUrlCommand command, String extension) {
         String fileName = LocalDate.now() + "_" + UUID.randomUUID();
-        return ImageUploadType.TEMP_PREFIX + command.type().buildPath(command.memberId()) + "/" + fileName + "." + extension;
+        Long entityId = command.type() == ImageUploadType.CREW_IMAGE ? command.crewId() : command.memberId();
+        return ImageUploadType.TEMP_PREFIX + command.type().buildPath(entityId) + "/" + fileName + "." + extension;
     }
 
     private String extractExtension(String fileName) {

--- a/src/main/java/com/youthexpedition/azit/modules/image/domain/model/enums/ImageErrorCode.java
+++ b/src/main/java/com/youthexpedition/azit/modules/image/domain/model/enums/ImageErrorCode.java
@@ -12,6 +12,7 @@ public enum ImageErrorCode implements BaseErrorCode {
     INVALID_FILE_NAME("INVALID_FILE_NAME", "올바르지 않은 파일명입니다.", HttpStatus.BAD_REQUEST),
     IMAGE_NOT_UPLOADED("IMAGE_NOT_UPLOADED", "이미지가 업로드되지 않았습니다. 먼저 이미지를 업로드해 주세요.", HttpStatus.BAD_REQUEST),
     IMAGE_OWNERSHIP_MISMATCH("IMAGE_OWNERSHIP_MISMATCH", "본인이 업로드한 이미지만 사용할 수 있습니다.", HttpStatus.FORBIDDEN),
+    CREW_ID_REQUIRED("CREW_ID_REQUIRED", "크루 이미지 업로드 시 crewId는 필수입니다.", HttpStatus.BAD_REQUEST),
     ;
 
     private final String code;

--- a/src/main/java/com/youthexpedition/azit/modules/image/domain/model/enums/ImageUploadType.java
+++ b/src/main/java/com/youthexpedition/azit/modules/image/domain/model/enums/ImageUploadType.java
@@ -13,15 +13,15 @@ public enum ImageUploadType {
 
     private final String directory;
 
-    public String buildPath(Long memberId) {
-        return directory + "/" + memberId;
+    public String buildPath(Long entityId) {
+        return directory + "/" + entityId;
     }
 
     /**
-     * temp S3 Key에서 memberId 추출
-     * 경로 구조: temp/{directory}/{memberId}/{fileName}
+     * temp S3 Key에서 entityId(memberId 또는 crewId) 추출
+     * 경로 구조: temp/{directory}/{entityId}/{fileName}
      */
-    public static Long extractMemberIdFromTempKey(String tempS3Key) {
+    public static Long extractEntityIdFromTempKey(String tempS3Key) {
         try {
             String[] parts = tempS3Key.split("/");
             return Long.parseLong(parts[2]);

--- a/src/main/java/com/youthexpedition/azit/modules/member/application/service/MemberService.java
+++ b/src/main/java/com/youthexpedition/azit/modules/member/application/service/MemberService.java
@@ -271,7 +271,7 @@ public class MemberService implements MemberUseCase {
     }
 
     private void validateImageOwnership(String tempS3Key, Long memberId) {
-        Long imageOwnerMemberId = ImageUploadType.extractMemberIdFromTempKey(tempS3Key);
+        Long imageOwnerMemberId = ImageUploadType.extractEntityIdFromTempKey(tempS3Key);
         if (imageOwnerMemberId == null) {
             throw new BusinessException(ImageErrorCode.IMAGE_NOT_UPLOADED);
         }


### PR DESCRIPTION
## 📌 관련 이슈
- #164

## ✨ 작업 내용
> 이번 PR에서 변경된 핵심 내용을 요약해주세요.

- 크루 이미지 업로드 API 구현

## 🧱 아키텍처 변경 요약
> 이번 작업으로 인해 변경된 주요 흐름을 적어주세요. (없으면 생략 가능)

- 예: 신규 UseCase 추가 및 외부 API 연동 어댑터 구현

## 📸 스크린샷 (선택 사항)
> API 테스트 결과 등을 첨부해주세요.
<img width="948" height="399" alt="image" src="https://github.com/user-attachments/assets/3bb77841-38f1-4ed8-879c-529ef9e1b38f" />
<img width="515" height="142" alt="image" src="https://github.com/user-attachments/assets/f6824737-9f07-440a-abd5-636898ee3f90" />


## ⚠️ 주의 사항 (선택)
- [ ] DB 스키마 변경이 있나요?
- [x] API 명세(Swagger)가 업데이트 되었나요?
- [ ] 새로운 환경 변수(.env)가 추가 되었나요?

## ✅ 셀프 체크리스트
- [ ] 브랜치 전략(develop)에 맞게 올렸나요?
- [ ] 커밋 컨벤션을 준수했나요?
- [ ] 불필요한 주석이나 print문은 제거했나요?
- [ ] 로컬에서 테스트는 성공했나요?