### PR TITLE
[FEAT] 크루 정보 수정 API 구현

### DIFF
--- a/src/main/java/com/youthexpedition/azit/modules/crew/adapter/in/web/CrewController.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/adapter/in/web/CrewController.java
@@ -8,6 +8,7 @@ import com.youthexpedition.azit.modules.crew.adapter.in.web.docs.CrewControllerD
 import com.youthexpedition.azit.modules.crew.adapter.in.web.dto.CreateCrewRequest;
 import com.youthexpedition.azit.modules.crew.adapter.in.web.dto.JoinCrewRequest;
 import com.youthexpedition.azit.modules.crew.adapter.in.web.dto.UpdateCrewImageRequest;
+import com.youthexpedition.azit.modules.crew.adapter.in.web.dto.UpdateCrewInfoRequest;
 import com.youthexpedition.azit.modules.crew.application.port.in.CrewUseCase;
 import com.youthexpedition.azit.modules.crew.application.port.in.command.ProcessJoinCommand;
 import com.youthexpedition.azit.modules.crew.application.port.in.dto.*;
@@ -105,6 +106,13 @@ public class CrewController implements CrewControllerDocs {
     @PatchMapping("/{crewId}/image")
     public CommonResponse<Void> updateCrewImage(@PathVariable Long crewId, @CurrentMemberId Long memberId, @Valid @RequestBody UpdateCrewImageRequest request) {
         crewUseCase.updateCrewImage(crewId, memberId, request.toCommand());
+
+        return CommonResponse.of(CommonSuccessCode.SUCCESS);
+    }
+
+    @PatchMapping("/{crewId}/info")
+    public CommonResponse<Void> updateCrewInfo(@PathVariable Long crewId, @CurrentMemberId Long memberId, @Valid @RequestBody UpdateCrewInfoRequest request) {
+        crewUseCase.updateCrewInfo(crewId, memberId, request.toCommand());
 
         return CommonResponse.of(CommonSuccessCode.SUCCESS);
     }

--- a/src/main/java/com/youthexpedition/azit/modules/crew/adapter/in/web/docs/CrewControllerDocs.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/adapter/in/web/docs/CrewControllerDocs.java
@@ -7,6 +7,7 @@ import com.youthexpedition.azit.infrastructure.config.swagger.ApiErrorCodeExampl
 import com.youthexpedition.azit.modules.crew.adapter.in.web.dto.CreateCrewRequest;
 import com.youthexpedition.azit.modules.crew.adapter.in.web.dto.JoinCrewRequest;
 import com.youthexpedition.azit.modules.crew.adapter.in.web.dto.UpdateCrewImageRequest;
+import com.youthexpedition.azit.modules.crew.adapter.in.web.dto.UpdateCrewInfoRequest;
 import com.youthexpedition.azit.modules.crew.application.port.in.dto.*;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -225,4 +226,24 @@ public interface CrewControllerDocs {
             @PathVariable Long crewId,
             @Parameter(hidden = true) @CurrentMemberId Long memberId,
             @Valid @RequestBody UpdateCrewImageRequest request);
+
+    @Operation(
+            summary = "크루 정보 수정",
+            description = """
+                    크루명과 크루 한줄 소개를 수정합니다. <br><br>
+
+                    **[제약 사항]** <br>
+                    * 리더만 크루 정보를 수정할 수 있습니다. (NOT_CREW_LEADER) <br>
+                    * 크루 이름은 필수이며 최대 15자까지 입력 가능합니다. <br>
+                    * 크루 한줄 소개는 선택이며 최대 20자까지 입력 가능합니다. (미입력 시 null로 저장)
+                    """
+    )
+    @ApiErrorCodeExamples({
+            "CREW_NOT_FOUND", "NOT_A_CREW_MEMBER", "NOT_CREW_LEADER",
+            "UNAUTHORIZED", "EXPIRED_TOKEN", "INVALID_TOKEN", "TOKEN_REUSE_DETECTED", "BLACKLISTED_TOKEN"
+    })
+    CommonResponse<Void> updateCrewInfo(
+            @PathVariable Long crewId,
+            @Parameter(hidden = true) @CurrentMemberId Long memberId,
+            @Valid @RequestBody UpdateCrewInfoRequest request);
 }

--- a/src/main/java/com/youthexpedition/azit/modules/crew/adapter/in/web/dto/UpdateCrewInfoRequest.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/adapter/in/web/dto/UpdateCrewInfoRequest.java
@@ -1,0 +1,21 @@
+package com.youthexpedition.azit.modules.crew.adapter.in.web.dto;
+
+import com.youthexpedition.azit.modules.crew.application.port.in.command.UpdateCrewInfoCommand;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record UpdateCrewInfoRequest(
+        @Schema(description = "크루 이름", requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotBlank(message = "크루 이름은 필수입니다.")
+        @Size(max = 15, message = "크루 이름은 최대 15자까지 가능합니다.")
+        String name,
+
+        @Schema(description = "크루 한줄 소개 (선택)", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+        @Size(max = 20, message = "크루 소개는 최대 20자까지 가능합니다.")
+        String description
+) {
+    public UpdateCrewInfoCommand toCommand() {
+        return UpdateCrewInfoCommand.of(name, description);
+    }
+}

--- a/src/main/java/com/youthexpedition/azit/modules/crew/application/port/in/CrewUseCase.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/application/port/in/CrewUseCase.java
@@ -5,6 +5,7 @@ import com.youthexpedition.azit.modules.crew.application.port.in.command.CreateC
 import com.youthexpedition.azit.modules.crew.application.port.in.command.JoinCrewCommand;
 import com.youthexpedition.azit.modules.crew.application.port.in.command.ProcessJoinCommand;
 import com.youthexpedition.azit.modules.crew.application.port.in.command.UpdateCrewImageCommand;
+import com.youthexpedition.azit.modules.crew.application.port.in.command.UpdateCrewInfoCommand;
 import com.youthexpedition.azit.modules.crew.application.port.in.dto.*;
 
 import java.util.List;
@@ -22,4 +23,5 @@ public interface CrewUseCase {
     void exitCrew(Long crewId, Long memberId);
     InvitationCodeResponse regenerateInvitationCode(Long crewId, Long memberId);
     void updateCrewImage(Long crewId, Long memberId, UpdateCrewImageCommand command);
+    void updateCrewInfo(Long crewId, Long memberId, UpdateCrewInfoCommand command);
 }

--- a/src/main/java/com/youthexpedition/azit/modules/crew/application/port/in/command/UpdateCrewInfoCommand.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/application/port/in/command/UpdateCrewInfoCommand.java
@@ -1,0 +1,10 @@
+package com.youthexpedition.azit.modules.crew.application.port.in.command;
+
+public record UpdateCrewInfoCommand(
+        String name,
+        String description
+) {
+    public static UpdateCrewInfoCommand of(String name, String description) {
+        return new UpdateCrewInfoCommand(name, description);
+    }
+}

--- a/src/main/java/com/youthexpedition/azit/modules/crew/application/service/CrewService.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/application/service/CrewService.java
@@ -424,10 +424,10 @@ public class CrewService implements CrewUseCase {
 
     @Override
     public void updateCrewInfo(Long crewId, Long memberId, UpdateCrewInfoCommand command) {
-        validateLeader(crewId, memberId);
-
         Crew crew = loadCrewPort.findById(crewId)
                 .orElseThrow(() -> new BusinessException(CrewErrorCode.CREW_NOT_FOUND));
+
+        validateLeader(crewId, memberId);
 
         crew.updateInfo(command.name(), command.description());
         saveCrewPort.save(crew);

--- a/src/main/java/com/youthexpedition/azit/modules/crew/application/service/CrewService.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/application/service/CrewService.java
@@ -10,6 +10,7 @@ import com.youthexpedition.azit.modules.crew.application.port.in.command.CreateC
 import com.youthexpedition.azit.modules.crew.application.port.in.command.JoinCrewCommand;
 import com.youthexpedition.azit.modules.crew.application.port.in.command.ProcessJoinCommand;
 import com.youthexpedition.azit.modules.crew.application.port.in.command.UpdateCrewImageCommand;
+import com.youthexpedition.azit.modules.crew.application.port.in.command.UpdateCrewInfoCommand;
 import com.youthexpedition.azit.modules.image.application.port.out.ImageStoragePort;
 import com.youthexpedition.azit.modules.image.domain.model.enums.ImageErrorCode;
 import com.youthexpedition.azit.modules.image.domain.model.enums.ImageUploadType;
@@ -418,6 +419,17 @@ public class CrewService implements CrewUseCase {
 
         // 상대 경로 저장
         crew.updateImageUrl("/" + finalS3Key);
+        saveCrewPort.save(crew);
+    }
+
+    @Override
+    public void updateCrewInfo(Long crewId, Long memberId, UpdateCrewInfoCommand command) {
+        validateLeader(crewId, memberId);
+
+        Crew crew = loadCrewPort.findById(crewId)
+                .orElseThrow(() -> new BusinessException(CrewErrorCode.CREW_NOT_FOUND));
+
+        crew.updateInfo(command.name(), command.description());
         saveCrewPort.save(crew);
     }
 

--- a/src/main/java/com/youthexpedition/azit/modules/crew/domain/model/Crew.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/domain/model/Crew.java
@@ -74,4 +74,9 @@ public class Crew {
     public void updateImageUrl(String imageUrl) {
         this.imageUrl = imageUrl;
     }
+
+    public void updateInfo(String name, String description) {
+        this.name = name;
+        this.description = description;
+    }
 }


### PR DESCRIPTION
## 📌 관련 이슈
- #164

## ✨ 작업 내용
> 이번 PR에서 변경된 핵심 내용을 요약해주세요.

- 크루 정보 수정 api 구현

## 🧱 아키텍처 변경 요약
> 이번 작업으로 인해 변경된 주요 흐름을 적어주세요. (없으면 생략 가능)

- 예: 신규 UseCase 추가 및 외부 API 연동 어댑터 구현

## 📸 스크린샷 (선택 사항)
> API 테스트 결과 등을 첨부해주세요.
<img width="961" height="417" alt="image" src="https://github.com/user-attachments/assets/a311c611-c93f-4409-a23c-ced61f92186b" />


## ⚠️ 주의 사항 (선택)
- [ ] DB 스키마 변경이 있나요?
- [x] API 명세(Swagger)가 업데이트 되었나요?
- [ ] 새로운 환경 변수(.env)가 추가 되었나요?

## ✅ 셀프 체크리스트
- [ ] 브랜치 전략(develop)에 맞게 올렸나요?
- [ ] 커밋 컨벤션을 준수했나요?
- [ ] 불필요한 주석이나 print문은 제거했나요?
- [ ] 로컬에서 테스트는 성공했나요?