### PR TITLE
[FEAT] 크루 정보 조회 api 구현

### DIFF
--- a/src/main/java/com/youthexpedition/azit/modules/crew/adapter/in/web/CrewController.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/adapter/in/web/CrewController.java
@@ -12,7 +12,6 @@ import com.youthexpedition.azit.modules.crew.adapter.in.web.dto.UpdateCrewInfoRe
 import com.youthexpedition.azit.modules.crew.application.port.in.CrewUseCase;
 import com.youthexpedition.azit.modules.crew.application.port.in.command.ProcessJoinCommand;
 import com.youthexpedition.azit.modules.crew.application.port.in.dto.*;
-import com.youthexpedition.azit.modules.crew.application.port.in.dto.CrewInfoResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;

--- a/src/main/java/com/youthexpedition/azit/modules/crew/adapter/in/web/CrewController.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/adapter/in/web/CrewController.java
@@ -12,6 +12,7 @@ import com.youthexpedition.azit.modules.crew.adapter.in.web.dto.UpdateCrewInfoRe
 import com.youthexpedition.azit.modules.crew.application.port.in.CrewUseCase;
 import com.youthexpedition.azit.modules.crew.application.port.in.command.ProcessJoinCommand;
 import com.youthexpedition.azit.modules.crew.application.port.in.dto.*;
+import com.youthexpedition.azit.modules.crew.application.port.in.dto.CrewInfoResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -108,6 +109,13 @@ public class CrewController implements CrewControllerDocs {
         crewUseCase.updateCrewImage(crewId, memberId, request.toCommand());
 
         return CommonResponse.of(CommonSuccessCode.SUCCESS);
+    }
+
+    @GetMapping("/{crewId}/info")
+    public CommonResponse<CrewInfoResponse> getCrewInfo(@PathVariable Long crewId, @CurrentMemberId Long memberId) {
+        CrewInfoResponse response = crewUseCase.getCrewInfo(crewId, memberId);
+
+        return CommonResponse.of(CommonSuccessCode.SUCCESS, response);
     }
 
     @PatchMapping("/{crewId}/info")

--- a/src/main/java/com/youthexpedition/azit/modules/crew/adapter/in/web/docs/CrewControllerDocs.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/adapter/in/web/docs/CrewControllerDocs.java
@@ -9,6 +9,7 @@ import com.youthexpedition.azit.modules.crew.adapter.in.web.dto.JoinCrewRequest;
 import com.youthexpedition.azit.modules.crew.adapter.in.web.dto.UpdateCrewImageRequest;
 import com.youthexpedition.azit.modules.crew.adapter.in.web.dto.UpdateCrewInfoRequest;
 import com.youthexpedition.azit.modules.crew.application.port.in.dto.*;
+import com.youthexpedition.azit.modules.crew.application.port.in.dto.CrewInfoResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -226,6 +227,23 @@ public interface CrewControllerDocs {
             @PathVariable Long crewId,
             @Parameter(hidden = true) @CurrentMemberId Long memberId,
             @Valid @RequestBody UpdateCrewImageRequest request);
+
+    @Operation(
+            summary = "크루 정보 조회",
+            description = """
+                    크루 이미지, 크루명, 크루 한줄 소개를 조회합니다. <br><br>
+
+                    **[제약 사항]** <br>
+                    * 해당 크루에 가입된 멤버(JOINED 상태)만 조회할 수 있습니다. (NOT_A_CREW_MEMBER)
+                    """
+    )
+    @ApiErrorCodeExamples({
+            "CREW_NOT_FOUND", "NOT_A_CREW_MEMBER",
+            "UNAUTHORIZED", "EXPIRED_TOKEN", "INVALID_TOKEN", "TOKEN_REUSE_DETECTED", "BLACKLISTED_TOKEN"
+    })
+    CommonResponse<CrewInfoResponse> getCrewInfo(
+            @PathVariable Long crewId,
+            @Parameter(hidden = true) @CurrentMemberId Long memberId);
 
     @Operation(
             summary = "크루 정보 수정",

--- a/src/main/java/com/youthexpedition/azit/modules/crew/application/port/in/CrewUseCase.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/application/port/in/CrewUseCase.java
@@ -7,6 +7,7 @@ import com.youthexpedition.azit.modules.crew.application.port.in.command.Process
 import com.youthexpedition.azit.modules.crew.application.port.in.command.UpdateCrewImageCommand;
 import com.youthexpedition.azit.modules.crew.application.port.in.command.UpdateCrewInfoCommand;
 import com.youthexpedition.azit.modules.crew.application.port.in.dto.*;
+import com.youthexpedition.azit.modules.crew.application.port.in.dto.CrewInfoResponse;
 
 import java.util.List;
 
@@ -24,4 +25,5 @@ public interface CrewUseCase {
     InvitationCodeResponse regenerateInvitationCode(Long crewId, Long memberId);
     void updateCrewImage(Long crewId, Long memberId, UpdateCrewImageCommand command);
     void updateCrewInfo(Long crewId, Long memberId, UpdateCrewInfoCommand command);
+    CrewInfoResponse getCrewInfo(Long crewId, Long memberId);
 }

--- a/src/main/java/com/youthexpedition/azit/modules/crew/application/port/in/dto/CrewInfoResponse.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/application/port/in/dto/CrewInfoResponse.java
@@ -1,0 +1,16 @@
+package com.youthexpedition.azit.modules.crew.application.port.in.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record CrewInfoResponse(
+        @Schema(description = "크루 이미지 URL")
+        String crewImageUrl,
+        @Schema(description = "크루 이름")
+        String name,
+        @Schema(description = "크루 한줄 소개")
+        String description
+) {
+    public static CrewInfoResponse of(String crewImageUrl, String name, String description) {
+        return new CrewInfoResponse(crewImageUrl, name, description);
+    }
+}

--- a/src/main/java/com/youthexpedition/azit/modules/crew/application/service/CrewService.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/application/service/CrewService.java
@@ -15,6 +15,7 @@ import com.youthexpedition.azit.modules.image.application.port.out.ImageStorageP
 import com.youthexpedition.azit.modules.image.domain.model.enums.ImageErrorCode;
 import com.youthexpedition.azit.modules.image.domain.model.enums.ImageUploadType;
 import com.youthexpedition.azit.modules.crew.application.port.in.dto.*;
+import com.youthexpedition.azit.modules.crew.application.port.in.dto.CrewInfoResponse;
 import com.youthexpedition.azit.modules.crew.application.port.out.LoadCrewMemberPort;
 import com.youthexpedition.azit.modules.crew.application.port.out.LoadCrewPort;
 import com.youthexpedition.azit.modules.crew.application.port.out.SaveCrewMemberPort;
@@ -420,6 +421,17 @@ public class CrewService implements CrewUseCase {
         // 상대 경로 저장
         crew.updateImageUrl("/" + finalS3Key);
         saveCrewPort.save(crew);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public CrewInfoResponse getCrewInfo(Long crewId, Long memberId) {
+        validateMember(crewId, memberId);
+
+        Crew crew = loadCrewPort.findById(crewId)
+                .orElseThrow(() -> new BusinessException(CrewErrorCode.CREW_NOT_FOUND));
+
+        return crewResponseMapper.toCrewInfoResponse(crew);
     }
 
     @Override

--- a/src/main/java/com/youthexpedition/azit/modules/crew/application/service/CrewService.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/application/service/CrewService.java
@@ -426,10 +426,10 @@ public class CrewService implements CrewUseCase {
     @Override
     @Transactional(readOnly = true)
     public CrewInfoResponse getCrewInfo(Long crewId, Long memberId) {
-        validateMember(crewId, memberId);
-
         Crew crew = loadCrewPort.findById(crewId)
                 .orElseThrow(() -> new BusinessException(CrewErrorCode.CREW_NOT_FOUND));
+
+        validateMember(crewId, memberId);
 
         return crewResponseMapper.toCrewInfoResponse(crew);
     }

--- a/src/main/java/com/youthexpedition/azit/modules/crew/application/service/mapper/CrewResponseMapper.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/application/service/mapper/CrewResponseMapper.java
@@ -2,6 +2,7 @@ package com.youthexpedition.azit.modules.crew.application.service.mapper;
 
 import com.youthexpedition.azit.infrastructure.common.util.ImageUrlFormatUtil;
 import com.youthexpedition.azit.modules.crew.application.port.in.dto.CreateCrewResponse;
+import com.youthexpedition.azit.modules.crew.application.port.in.dto.CrewInfoResponse;
 import com.youthexpedition.azit.modules.crew.application.port.in.dto.CrewInvitationResponse;
 import com.youthexpedition.azit.modules.crew.application.port.in.dto.CrewJoinStatusResponse;
 import com.youthexpedition.azit.modules.crew.domain.model.Crew;
@@ -30,6 +31,14 @@ public class CrewResponseMapper {
                 crew.getCategory().name(),
                 crew.getMemberCount(),
                 imageUrlFormatUtil.buildFullImageUrl(crew.getImageUrl()),
+                crew.getDescription()
+        );
+    }
+
+    public CrewInfoResponse toCrewInfoResponse(Crew crew) {
+        return CrewInfoResponse.of(
+                imageUrlFormatUtil.buildFullImageUrl(crew.getImageUrl()),
+                crew.getName(),
                 crew.getDescription()
         );
     }


### PR DESCRIPTION
## 📌 관련 이슈
- closes #164

## ✨ 작업 내용
> 이번 PR에서 변경된 핵심 내용을 요약해주세요.

- 크루 정보 조회 API 구현

## 🧱 아키텍처 변경 요약
> 이번 작업으로 인해 변경된 주요 흐름을 적어주세요. (없으면 생략 가능)

- 예: 신규 UseCase 추가 및 외부 API 연동 어댑터 구현

## 📸 스크린샷 (선택 사항)
> API 테스트 결과 등을 첨부해주세요.
<img width="957" height="419" alt="image" src="https://github.com/user-attachments/assets/a9812a26-c846-42c5-aa67-49be258d29d5" />

## ⚠️ 주의 사항 (선택)
- [ ] DB 스키마 변경이 있나요?
- [x] API 명세(Swagger)가 업데이트 되었나요?
- [ ] 새로운 환경 변수(.env)가 추가 되었나요?

## ✅ 셀프 체크리스트
- [ ] 브랜치 전략(develop)에 맞게 올렸나요?
- [ ] 커밋 컨벤션을 준수했나요?
- [ ] 불필요한 주석이나 print문은 제거했나요?
- [ ] 로컬에서 테스트는 성공했나요?