### PR TITLE
[FEAT] 크루 신청 취소 API 구현

### DIFF
--- a/src/main/java/com/youthexpedition/azit/modules/crew/adapter/in/web/CrewController.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/adapter/in/web/CrewController.java
@@ -81,6 +81,13 @@ public class CrewController implements CrewControllerDocs {
         return CommonResponse.of(CommonSuccessCode.SUCCESS, response);
     }
 
+    @DeleteMapping("/{crewId}/join-request")
+    public CommonResponse<Void> cancelJoinRequest(@PathVariable Long crewId, @CurrentMemberId Long memberId) {
+        crewUseCase.cancelJoinRequest(crewId, memberId);
+
+        return CommonResponse.of(CommonSuccessCode.SUCCESS);
+    }
+
     @DeleteMapping("/{crewId}/members/me")
     public CommonResponse<Void> exitCrew(@PathVariable Long crewId, @CurrentMemberId Long memberId) {
         crewUseCase.exitCrew(crewId, memberId);

--- a/src/main/java/com/youthexpedition/azit/modules/crew/adapter/in/web/docs/CrewControllerDocs.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/adapter/in/web/docs/CrewControllerDocs.java
@@ -152,6 +152,23 @@ public interface CrewControllerDocs {
     CommonResponse<CrewMemberListResponse> getCrewMembers(@PathVariable Long crewId, @CurrentMemberId Long memberId, CursorPageQuery query);
 
     @Operation(
+            summary = "크루 가입 신청 취소",
+            description = """
+                    승인 대기 중인 크루 가입 신청을 취소합니다. <br><br>
+
+                    **[제약 사항]** <br>
+                    * 가입 신청(REQUESTED) 상태인 경우에만 취소가 가능합니다. (JOIN_REQUEST_NOT_FOUND) <br>
+                    * 취소 후 24시간 이내에는 동일 크루에 재신청이 불가합니다. (CANCEL_REJOINING_COOLDOWN)
+                    """
+    )
+    @ApiErrorCodeExamples({
+            "JOIN_REQUEST_NOT_FOUND", "MEMBER_NOT_FOUND", "CANCEL_REJOINING_COOLDOWN",
+            "UNAUTHORIZED", "EXPIRED_TOKEN", "INVALID_TOKEN", "TOKEN_REUSE_DETECTED", "BLACKLISTED_TOKEN"
+    })
+    CommonResponse<Void> cancelJoinRequest(
+            @PathVariable Long crewId, @Parameter(hidden = true) @CurrentMemberId Long memberId);
+
+    @Operation(
             summary = "크루 탈퇴",
             description = """
             로그인한 사용자가 특정 크루에서 자진 탈퇴합니다. <br><br>

--- a/src/main/java/com/youthexpedition/azit/modules/crew/adapter/out/persistence/entity/CrewMemberEntity.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/adapter/out/persistence/entity/CrewMemberEntity.java
@@ -40,4 +40,7 @@ public class CrewMemberEntity extends BaseTimeEntity {
 
     @Column(name = "exited_at")
     private LocalDateTime exitedAt;
+
+    @Column(name = "cancelled_at")
+    private LocalDateTime cancelledAt;
 }

--- a/src/main/java/com/youthexpedition/azit/modules/crew/adapter/out/persistence/mapper/CrewMemberMapper.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/adapter/out/persistence/mapper/CrewMemberMapper.java
@@ -19,6 +19,7 @@ public class CrewMemberMapper {
                 .status(entity.getStatus())
                 .expelledAt(entity.getExpelledAt())
                 .exitedAt(entity.getExitedAt())
+                .cancelledAt(entity.getCancelledAt())
                 .createdAt(entity.getCreatedAt())
                 .updatedAt(entity.getUpdatedAt())
                 .build();
@@ -33,6 +34,7 @@ public class CrewMemberMapper {
                 .status(domain.getStatus())
                 .expelledAt(domain.getExpelledAt())
                 .exitedAt(domain.getExitedAt())
+                .cancelledAt(domain.getCancelledAt())
                 .build();
     }
 }

--- a/src/main/java/com/youthexpedition/azit/modules/crew/application/port/in/CrewUseCase.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/application/port/in/CrewUseCase.java
@@ -20,6 +20,7 @@ public interface CrewUseCase {
     List<JoinRequestMemberResponse> getJoinRequests(Long crewId, Long memberId);
     CrewMemberListResponse getCrewMembers(Long crewId, Long memberId, CursorPageQuery query);
     void expelCrewMember(Long crewId, Long leaderId, Long targetMemberId);
+    void cancelJoinRequest(Long crewId, Long memberId);
     void exitCrew(Long crewId, Long memberId);
     InvitationCodeResponse regenerateInvitationCode(Long crewId, Long memberId);
     void updateCrewProfile(Long crewId, Long memberId, UpdateCrewProfileCommand command);

--- a/src/main/java/com/youthexpedition/azit/modules/crew/application/service/CrewService.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/application/service/CrewService.java
@@ -346,8 +346,13 @@ public class CrewService implements CrewUseCase {
         Member member = loadMemberPort.findById(memberId)
                 .orElseThrow(() -> new BusinessException(MemberErrorCode.MEMBER_NOT_FOUND));
 
-        member.resetToOnboarding();
-        saveMemberPort.save(member);
+        // 다른 크루에 가입된 크루가 없을 경우에만 온보딩 대기 상태로 변경
+        long joinedCrewCount = loadCrewMemberPort.countJoinedCrewsByMemberId(memberId);
+        if (joinedCrewCount == 0) {
+            log.info("[CREW] memberId: {}, 가입된 크루가 없으므로 온보딩 상태로 변경합니다.", memberId);
+            member.resetToOnboarding();
+            saveMemberPort.save(member);
+        }
     }
 
     @Override

--- a/src/main/java/com/youthexpedition/azit/modules/crew/application/service/CrewService.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/application/service/CrewService.java
@@ -139,6 +139,11 @@ public class CrewService implements CrewUseCase {
                                 throw new BusinessException(CrewErrorCode.EXIT_REJOINING_COOLDOWN);
                             }
 
+                            // 가입 신청 취소 후 24시간 이내 재신청 차단
+                            if (existingMember.getStatus() == CrewMemberStatus.CANCELLED && existingMember.isCancelCooldownActive(now)) {
+                                throw new BusinessException(CrewErrorCode.CANCEL_REJOINING_COOLDOWN);
+                            }
+
                             // 탈퇴, 방출(쿨다운 지남), 거절 상태일 경우 재신청
                             existingMember.reJoin();
                             saveCrewMemberPort.save(existingMember);
@@ -321,6 +326,27 @@ public class CrewService implements CrewUseCase {
         }
 
         member.expel();
+        saveMemberPort.save(member);
+    }
+
+    @Override
+    @Transactional
+    public void cancelJoinRequest(Long crewId, Long memberId) {
+        CrewMember crewMember = loadCrewMemberPort.findByCrewIdAndMemberId(crewId, memberId)
+                .orElseThrow(() -> new BusinessException(CrewErrorCode.JOIN_REQUEST_NOT_FOUND));
+
+        if (!crewMember.isJoinRequested()) {
+            throw new BusinessException(CrewErrorCode.JOIN_REQUEST_NOT_FOUND);
+        }
+
+        crewMember.cancel(LocalDateTime.now());
+        saveCrewMemberPort.save(crewMember);
+        log.info("[CREW] crewId: {}, memberId: {} 가 가입 신청을 취소합니다.", crewId, memberId);
+
+        Member member = loadMemberPort.findById(memberId)
+                .orElseThrow(() -> new BusinessException(MemberErrorCode.MEMBER_NOT_FOUND));
+
+        member.resetToOnboarding();
         saveMemberPort.save(member);
     }
 

--- a/src/main/java/com/youthexpedition/azit/modules/crew/domain/model/CrewMember.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/domain/model/CrewMember.java
@@ -19,6 +19,7 @@ public class CrewMember {
     private CrewMemberStatus status;
     private LocalDateTime expelledAt;
     private LocalDateTime exitedAt;
+    private LocalDateTime cancelledAt;
     private final LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 
@@ -81,6 +82,18 @@ public class CrewMember {
     public boolean isRejoinCooldownActive(LocalDateTime now) {
         if (this.expelledAt == null) return false;
         return this.expelledAt.plusHours(REJOINING_COOLDOWN_HOURS).isAfter(now);
+    }
+
+    // 가입 신청 취소 (본인)
+    public void cancel(LocalDateTime cancelledAt) {
+        this.status = CrewMemberStatus.CANCELLED;
+        this.cancelledAt = cancelledAt;
+    }
+
+    // 취소 후 재신청 쿨다운 여부 확인 (24시간)
+    public boolean isCancelCooldownActive(LocalDateTime now) {
+        if (this.cancelledAt == null) return false;
+        return this.cancelledAt.plusHours(REJOINING_COOLDOWN_HOURS).isAfter(now);
     }
 
     // 가입 재신청

--- a/src/main/java/com/youthexpedition/azit/modules/crew/domain/model/enums/CrewErrorCode.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/domain/model/enums/CrewErrorCode.java
@@ -24,6 +24,7 @@ public enum CrewErrorCode implements BaseErrorCode {
     CANNOT_SERVICE_WITHDRAW_AS_LEADER("CANNOT_SERVICE_WITHDRAW_AS_LEADER", "리더로 활동 중인 크루가 있습니다. 권한을 위임하거나 크루를 해산한 후 서비스를 탈퇴할 수 있습니다.", HttpStatus.BAD_REQUEST),
     EXPELLED_REJOINING_COOLDOWN("EXPELLED_REJOINING_COOLDOWN", "방출 후 24시간이 지나지 않아 재가입 요청이 불가합니다.", HttpStatus.BAD_REQUEST),
     EXIT_REJOINING_COOLDOWN("EXIT_REJOINING_COOLDOWN", "탈퇴 후 24시간이 지나지 않아 재가입 요청이 불가합니다.", HttpStatus.BAD_REQUEST),
+    CANCEL_REJOINING_COOLDOWN("CANCEL_REJOINING_COOLDOWN", "가입 신청 취소 후 24시간이 지나지 않아 재가입 요청이 불가합니다.", HttpStatus.BAD_REQUEST),
 
     // 일정 관련
     INVALID_SCHEDULE_TIME("INVALID_SCHEDULE_TIME", "유효하지 않은 일정 시간입니다.", HttpStatus.BAD_REQUEST),

--- a/src/main/java/com/youthexpedition/azit/modules/crew/domain/model/enums/CrewMemberStatus.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/domain/model/enums/CrewMemberStatus.java
@@ -1,9 +1,10 @@
 package com.youthexpedition.azit.modules.crew.domain.model.enums;
 
 public enum CrewMemberStatus {
-    REQUESTED, // 가입 요청
-    JOINED, // 가입 완료
-    REJECTED, // 가입 거절
-    EXITED, // 탈퇴
-    EXPELLED // 방출
+    REQUESTED,  // 가입 요청
+    JOINED,     // 가입 완료
+    REJECTED,   // 가입 거절
+    EXITED,     // 탈퇴
+    EXPELLED,   // 방출
+    CANCELLED   // 가입 신청 취소
 }

--- a/src/test/java/com/youthexpedition/azit/modules/crew/application/service/CrewServiceTest.java
+++ b/src/test/java/com/youthexpedition/azit/modules/crew/application/service/CrewServiceTest.java
@@ -294,6 +294,7 @@ class CrewServiceTest {
                     .status(CrewMemberStatus.REQUESTED)
                     .build();
             given(loadCrewMemberPort.findByCrewIdAndMemberId(crewId, memberId)).willReturn(Optional.of(requestedMember));
+            given(loadCrewMemberPort.countJoinedCrewsByMemberId(memberId)).willReturn(0L);
 
             Member member = Member.builder()
                     .id(memberId)
@@ -311,8 +312,8 @@ class CrewServiceTest {
         }
 
         @Test
-        @DisplayName("성공: 취소 후 멤버 상태가 PENDING_ONBOARDING으로 복구된다.")
-        void cancelJoinRequest_Success_MemberStatusRestored() {
+        @DisplayName("성공: 다른 가입 크루가 없으면 멤버 상태가 PENDING_ONBOARDING으로 변경된다.")
+        void cancelJoinRequest_Success_NoOtherCrews_ResetToOnboarding() {
             // given
             CrewMember requestedMember = CrewMember.builder()
                     .crewId(crewId)
@@ -321,6 +322,7 @@ class CrewServiceTest {
                     .status(CrewMemberStatus.REQUESTED)
                     .build();
             given(loadCrewMemberPort.findByCrewIdAndMemberId(crewId, memberId)).willReturn(Optional.of(requestedMember));
+            given(loadCrewMemberPort.countJoinedCrewsByMemberId(memberId)).willReturn(0L);
 
             Member member = Member.builder()
                     .id(memberId)
@@ -334,6 +336,33 @@ class CrewServiceTest {
             // then
             assertThat(member.getStatus()).isEqualTo(MemberStatus.PENDING_ONBOARDING);
             verify(saveMemberPort, times(1)).save(member);
+        }
+
+        @Test
+        @DisplayName("성공: 다른 가입 크루가 있으면 멤버 상태가 ACTIVE로 유지된다.")
+        void cancelJoinRequest_Success_HasOtherCrews_KeepsActive() {
+            // given
+            CrewMember requestedMember = CrewMember.builder()
+                    .crewId(crewId)
+                    .memberId(memberId)
+                    .role(CrewMemberRole.MEMBER)
+                    .status(CrewMemberStatus.REQUESTED)
+                    .build();
+            given(loadCrewMemberPort.findByCrewIdAndMemberId(crewId, memberId)).willReturn(Optional.of(requestedMember));
+            given(loadCrewMemberPort.countJoinedCrewsByMemberId(memberId)).willReturn(1L); // 다른 크루에 가입 중
+
+            Member member = Member.builder()
+                    .id(memberId)
+                    .status(MemberStatus.WAITING_FOR_APPROVE)
+                    .build();
+            given(loadMemberPort.findById(memberId)).willReturn(Optional.of(member));
+
+            // when
+            crewService.cancelJoinRequest(crewId, memberId);
+
+            // then
+            assertThat(member.getStatus()).isEqualTo(MemberStatus.WAITING_FOR_APPROVE); // 상태 변경 없음
+            verify(saveMemberPort, never()).save(any());
         }
 
         @Test

--- a/src/test/java/com/youthexpedition/azit/modules/crew/application/service/CrewServiceTest.java
+++ b/src/test/java/com/youthexpedition/azit/modules/crew/application/service/CrewServiceTest.java
@@ -213,6 +213,177 @@ class CrewServiceTest {
                     .isInstanceOf(BusinessException.class)
                     .hasMessageContaining(CrewErrorCode.CREW_NOT_FOUND.getMessage());
         }
+
+        @Test
+        @DisplayName("실패: 취소(CANCELLED) 후 24시간 이내에 재신청하면 CANCEL_REJOINING_COOLDOWN 예외가 발생한다.")
+        void joinCrew_Fail_CancelCooldown() {
+            // given
+            Long crewId = 100L;
+            Long memberId = 1L;
+            String invitationCode = "ABC123";
+            JoinCrewCommand command = JoinCrewCommand.of(memberId, invitationCode);
+
+            Crew mockCrew = Crew.builder().id(crewId).invitationCode(invitationCode).build();
+            given(loadCrewPort.findByInvitationCode(invitationCode)).willReturn(Optional.of(mockCrew));
+
+            CrewMember cancelledMember = CrewMember.builder()
+                    .crewId(crewId)
+                    .memberId(memberId)
+                    .status(CrewMemberStatus.CANCELLED)
+                    .cancelledAt(LocalDateTime.now().minusHours(1)) // 1시간 전 취소 (쿨다운 중)
+                    .build();
+            given(loadCrewMemberPort.findByCrewIdAndMemberId(crewId, memberId)).willReturn(Optional.of(cancelledMember));
+
+            // when & then
+            assertThatThrownBy(() -> crewService.joinCrew(command))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessageContaining(CrewErrorCode.CANCEL_REJOINING_COOLDOWN.getMessage());
+        }
+
+        @Test
+        @DisplayName("성공: 취소(CANCELLED) 후 24시간이 지나면 재신청이 가능하고 REQUESTED 상태로 변경된다.")
+        void joinCrew_Success_AfterCancelCooldown() {
+            // given
+            Long crewId = 100L;
+            Long memberId = 1L;
+            String invitationCode = "ABC123";
+            JoinCrewCommand command = JoinCrewCommand.of(memberId, invitationCode);
+
+            Crew mockCrew = Crew.builder().id(crewId).invitationCode(invitationCode).build();
+            given(loadCrewPort.findByInvitationCode(invitationCode)).willReturn(Optional.of(mockCrew));
+
+            CrewMember cancelledMember = CrewMember.builder()
+                    .crewId(crewId)
+                    .memberId(memberId)
+                    .status(CrewMemberStatus.CANCELLED)
+                    .cancelledAt(LocalDateTime.now().minusHours(25)) // 25시간 전 취소 (쿨다운 종료)
+                    .build();
+            given(loadCrewMemberPort.findByCrewIdAndMemberId(crewId, memberId)).willReturn(Optional.of(cancelledMember));
+
+            Member member = Member.builder()
+                    .id(memberId)
+                    .status(MemberStatus.PENDING_ONBOARDING)
+                    .build();
+            given(loadMemberPort.findById(memberId)).willReturn(Optional.of(member));
+
+            // when
+            crewService.joinCrew(command);
+
+            // then
+            assertThat(cancelledMember.getStatus()).isEqualTo(CrewMemberStatus.REQUESTED);
+            verify(saveCrewMemberPort, times(1)).save(cancelledMember);
+            assertThat(member.getStatus()).isEqualTo(MemberStatus.WAITING_FOR_APPROVE);
+        }
+    }
+
+    @Nested
+    @DisplayName("가입 신청 취소 테스트")
+    class CancelJoinRequestTest {
+
+        private final Long crewId = 100L;
+        private final Long memberId = 1L;
+
+        @Test
+        @DisplayName("성공: REQUESTED 상태일 때 취소하면 CANCELLED 상태로 변경되고 cancelledAt이 기록된다.")
+        void cancelJoinRequest_Success() {
+            // given
+            CrewMember requestedMember = CrewMember.builder()
+                    .crewId(crewId)
+                    .memberId(memberId)
+                    .role(CrewMemberRole.MEMBER)
+                    .status(CrewMemberStatus.REQUESTED)
+                    .build();
+            given(loadCrewMemberPort.findByCrewIdAndMemberId(crewId, memberId)).willReturn(Optional.of(requestedMember));
+
+            Member member = Member.builder()
+                    .id(memberId)
+                    .status(MemberStatus.WAITING_FOR_APPROVE)
+                    .build();
+            given(loadMemberPort.findById(memberId)).willReturn(Optional.of(member));
+
+            // when
+            crewService.cancelJoinRequest(crewId, memberId);
+
+            // then
+            assertThat(requestedMember.getStatus()).isEqualTo(CrewMemberStatus.CANCELLED);
+            assertThat(requestedMember.getCancelledAt()).isNotNull();
+            verify(saveCrewMemberPort, times(1)).save(requestedMember);
+        }
+
+        @Test
+        @DisplayName("성공: 취소 후 멤버 상태가 PENDING_ONBOARDING으로 복구된다.")
+        void cancelJoinRequest_Success_MemberStatusRestored() {
+            // given
+            CrewMember requestedMember = CrewMember.builder()
+                    .crewId(crewId)
+                    .memberId(memberId)
+                    .role(CrewMemberRole.MEMBER)
+                    .status(CrewMemberStatus.REQUESTED)
+                    .build();
+            given(loadCrewMemberPort.findByCrewIdAndMemberId(crewId, memberId)).willReturn(Optional.of(requestedMember));
+
+            Member member = Member.builder()
+                    .id(memberId)
+                    .status(MemberStatus.WAITING_FOR_APPROVE)
+                    .build();
+            given(loadMemberPort.findById(memberId)).willReturn(Optional.of(member));
+
+            // when
+            crewService.cancelJoinRequest(crewId, memberId);
+
+            // then
+            assertThat(member.getStatus()).isEqualTo(MemberStatus.PENDING_ONBOARDING);
+            verify(saveMemberPort, times(1)).save(member);
+        }
+
+        @Test
+        @DisplayName("실패: 가입 신청 내역이 없으면 JOIN_REQUEST_NOT_FOUND 예외가 발생한다.")
+        void cancelJoinRequest_Fail_NoRequest() {
+            // given
+            given(loadCrewMemberPort.findByCrewIdAndMemberId(crewId, memberId)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> crewService.cancelJoinRequest(crewId, memberId))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessageContaining(CrewErrorCode.JOIN_REQUEST_NOT_FOUND.getMessage());
+
+            verify(saveCrewMemberPort, never()).save(any());
+            verify(saveMemberPort, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("실패: 이미 승인된(JOINED) 상태에서 취소하면 JOIN_REQUEST_NOT_FOUND 예외가 발생한다.")
+        void cancelJoinRequest_Fail_AlreadyJoined() {
+            // given
+            CrewMember joinedMember = CrewMember.builder()
+                    .crewId(crewId)
+                    .memberId(memberId)
+                    .status(CrewMemberStatus.JOINED)
+                    .build();
+            given(loadCrewMemberPort.findByCrewIdAndMemberId(crewId, memberId)).willReturn(Optional.of(joinedMember));
+
+            // when & then
+            assertThatThrownBy(() -> crewService.cancelJoinRequest(crewId, memberId))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessageContaining(CrewErrorCode.JOIN_REQUEST_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        @DisplayName("실패: 이미 거절된(REJECTED) 상태에서 취소하면 JOIN_REQUEST_NOT_FOUND 예외가 발생한다.")
+        void cancelJoinRequest_Fail_AlreadyRejected() {
+            // given
+            CrewMember rejectedMember = CrewMember.builder()
+                    .crewId(crewId)
+                    .memberId(memberId)
+                    .status(CrewMemberStatus.REJECTED)
+                    .build();
+            given(loadCrewMemberPort.findByCrewIdAndMemberId(crewId, memberId)).willReturn(Optional.of(rejectedMember));
+
+            // when & then
+            assertThatThrownBy(() -> crewService.cancelJoinRequest(crewId, memberId))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessageContaining(CrewErrorCode.JOIN_REQUEST_NOT_FOUND.getMessage());
+        }
     }
 
     @Nested


### PR DESCRIPTION
## 📌 관련 이슈
- #174

## ✨ 작업 내용
> 이번 PR에서 변경된 핵심 내용을 요약해주세요.

- 크루 신청 취소 API 구현

## 🧱 아키텍처 변경 요약
> 이번 작업으로 인해 변경된 주요 흐름을 적어주세요. (없으면 생략 가능)

- 예: 신규 UseCase 추가 및 외부 API 연동 어댑터 구현

## 📸 스크린샷 (선택 사항)
> API 테스트 결과 등을 첨부해주세요.
<img width="878" height="428" alt="image" src="https://github.com/user-attachments/assets/9e5a5ee5-cbfe-43f7-8944-ddfe9ca605e4" />

## ⚠️ 주의 사항 (선택)
- [x] DB 스키마 변경이 있나요?
- [x] API 명세(Swagger)가 업데이트 되었나요?
- [ ] 새로운 환경 변수(.env)가 추가 되었나요?

## ✅ 셀프 체크리스트
- [ ] 브랜치 전략(develop)에 맞게 올렸나요?
- [ ] 커밋 컨벤션을 준수했나요?
- [ ] 불필요한 주석이나 print문은 제거했나요?
- [ ] 로컬에서 테스트는 성공했나요?