### PR TITLE
[FEAT] 출석 로그 조회 시 crewId 필터링 기능 추가

### DIFF
--- a/src/main/java/com/youthexpedition/azit/modules/crew/adapter/out/persistence/CrewSchedulePersistenceAdapter.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/adapter/out/persistence/CrewSchedulePersistenceAdapter.java
@@ -95,15 +95,15 @@ public class CrewSchedulePersistenceAdapter implements LoadCrewSchedulePort, Sav
     }
 
     @Override
-    public List<CrewSchedule> findAllByMemberIdAndMonth(Long memberId, YearMonth yearMonth, LocalDateTime now) {
-        return crewScheduleRepository.findAllByMemberIdAndMonth(memberId, yearMonth, now).stream()
+    public List<CrewSchedule> findAllByMemberIdAndMonth(Long memberId, YearMonth yearMonth, LocalDateTime now, Long crewId) {
+        return crewScheduleRepository.findAllByMemberIdAndMonth(memberId, yearMonth, now, crewId).stream()
                 .map(crewScheduleMapper::toDomain)
                 .toList();
     }
 
     @Override
-    public Map<LocalDate, Set<RunType>> findMyMonthlyAttendanceForCalendar(Long memberId, YearMonth yearMonth, LocalDateTime now) {
-        return crewScheduleRepository.findMyMonthlyAttendanceForCalendar(memberId, yearMonth, now);
+    public Map<LocalDate, Set<RunType>> findMyMonthlyAttendanceForCalendar(Long memberId, YearMonth yearMonth, LocalDateTime now, Long crewId) {
+        return crewScheduleRepository.findMyMonthlyAttendanceForCalendar(memberId, yearMonth, now, crewId);
     }
 
     @Override

--- a/src/main/java/com/youthexpedition/azit/modules/crew/adapter/out/persistence/repository/CrewScheduleRepositoryCustom.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/adapter/out/persistence/repository/CrewScheduleRepositoryCustom.java
@@ -17,8 +17,8 @@ public interface CrewScheduleRepositoryCustom {
     List<CrewScheduleEntity> findAllByMemberId(Long memberId);
     List<CrewScheduleEntity> findAllTodaySchedulesByMemberId(Long memberId, LocalDateTime now);
     Optional<CrewScheduleEntity> findNextClosestScheduleByMemberId(Long memberId, LocalDateTime now);
-    List<CrewScheduleEntity> findAllByMemberIdAndMonth(Long memberId, YearMonth yearMonth, LocalDateTime now);
-    Map<LocalDate, Set<RunType>> findMyMonthlyAttendanceForCalendar(Long memberId, YearMonth yearMonth, LocalDateTime now);
+    List<CrewScheduleEntity> findAllByMemberIdAndMonth(Long memberId, YearMonth yearMonth, LocalDateTime now, Long crewId);
+    Map<LocalDate, Set<RunType>> findMyMonthlyAttendanceForCalendar(Long memberId, YearMonth yearMonth, LocalDateTime now, Long crewId);
     boolean existsConflictingSchedule(Long memberId, LocalDateTime newMeetingAt, Long excludeScheduleId);
     List<CrewScheduleEntity> findSchedulesToCancelByCreator(Long crewId, Long memberId, LocalDateTime now);
     List<CrewScheduleEntity> findSchedulesToRemoveParticipant(Long crewId, Long memberId, LocalDateTime now);

--- a/src/main/java/com/youthexpedition/azit/modules/crew/adapter/out/persistence/repository/CrewScheduleRepositoryImpl.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/adapter/out/persistence/repository/CrewScheduleRepositoryImpl.java
@@ -106,7 +106,7 @@ public class CrewScheduleRepositoryImpl implements CrewScheduleRepositoryCustom 
     }
 
     @Override
-    public List<CrewScheduleEntity> findAllByMemberIdAndMonth(Long memberId, YearMonth yearMonth, LocalDateTime now) {
+    public List<CrewScheduleEntity> findAllByMemberIdAndMonth(Long memberId, YearMonth yearMonth, LocalDateTime now, Long crewId) {
         LocalDateTime start = yearMonth.atDay(1).atStartOfDay();
         LocalDateTime end = yearMonth.atEndOfMonth().atTime(LocalTime.MAX);
 
@@ -114,17 +114,18 @@ public class CrewScheduleRepositoryImpl implements CrewScheduleRepositoryCustom 
                 .join(crewScheduleEntity.members, crewScheduleMemberEntity)
                 .where(
                         crewScheduleMemberEntity.memberId.eq(memberId),
-                        crewScheduleEntity.status.eq(ScheduleStatus.ACTIVE), // 삭제된 일정 제외
+                        crewScheduleEntity.status.eq(ScheduleStatus.ACTIVE),
                         crewScheduleEntity.meetingAt.between(start, end),
                         crewScheduleMemberEntity.isCheckedIn.isTrue()
-                                .or(crewScheduleEntity.meetingAt.lt(now.minusHours(ACTIVE_CHECK_IN_WINDOW_HOURS)))
+                                .or(crewScheduleEntity.meetingAt.lt(now.minusHours(ACTIVE_CHECK_IN_WINDOW_HOURS))),
+                        crewId != null ? crewScheduleEntity.crewId.eq(crewId) : null
                 )
-                .orderBy(crewScheduleEntity.meetingAt.desc()) // 최신순 정렬
+                .orderBy(crewScheduleEntity.meetingAt.desc())
                 .fetch();
     }
 
     @Override
-    public Map<LocalDate, Set<RunType>> findMyMonthlyAttendanceForCalendar(Long memberId, YearMonth yearMonth, LocalDateTime now) {
+    public Map<LocalDate, Set<RunType>> findMyMonthlyAttendanceForCalendar(Long memberId, YearMonth yearMonth, LocalDateTime now, Long crewId) {
         LocalDateTime start = yearMonth.atDay(1).atStartOfDay();
         LocalDateTime end = yearMonth.atEndOfMonth().atTime(LocalTime.MAX);
 
@@ -137,7 +138,8 @@ public class CrewScheduleRepositoryImpl implements CrewScheduleRepositoryCustom 
                         crewScheduleEntity.status.eq(ScheduleStatus.ACTIVE),
                         crewScheduleEntity.meetingAt.between(start, end),
                         crewScheduleMemberEntity.isCheckedIn.isTrue()
-                                .or(crewScheduleEntity.meetingAt.lt(now.minusHours(ACTIVE_CHECK_IN_WINDOW_HOURS)))
+                                .or(crewScheduleEntity.meetingAt.lt(now.minusHours(ACTIVE_CHECK_IN_WINDOW_HOURS))),
+                        crewId != null ? crewScheduleEntity.crewId.eq(crewId) : null
                 )
                 .fetch();
 

--- a/src/main/java/com/youthexpedition/azit/modules/crew/adapter/out/persistence/repository/CrewScheduleRepositoryImpl.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/adapter/out/persistence/repository/CrewScheduleRepositoryImpl.java
@@ -118,7 +118,7 @@ public class CrewScheduleRepositoryImpl implements CrewScheduleRepositoryCustom 
                         crewScheduleEntity.meetingAt.between(start, end),
                         crewScheduleMemberEntity.isCheckedIn.isTrue()
                                 .or(crewScheduleEntity.meetingAt.lt(now.minusHours(ACTIVE_CHECK_IN_WINDOW_HOURS))),
-                        crewId != null ? crewScheduleEntity.crewId.eq(crewId) : null
+                        eqCrewId(crewId)
                 )
                 .orderBy(crewScheduleEntity.meetingAt.desc())
                 .fetch();
@@ -139,7 +139,7 @@ public class CrewScheduleRepositoryImpl implements CrewScheduleRepositoryCustom 
                         crewScheduleEntity.meetingAt.between(start, end),
                         crewScheduleMemberEntity.isCheckedIn.isTrue()
                                 .or(crewScheduleEntity.meetingAt.lt(now.minusHours(ACTIVE_CHECK_IN_WINDOW_HOURS))),
-                        crewId != null ? crewScheduleEntity.crewId.eq(crewId) : null
+                        eqCrewId(crewId)
                 )
                 .fetch();
 
@@ -208,6 +208,10 @@ public class CrewScheduleRepositoryImpl implements CrewScheduleRepositoryCustom 
 
     private BooleanExpression eqRunType(RunType runType) {
         return runType != null ? crewScheduleEntity.runType.eq(runType) : null;
+    }
+
+    private BooleanExpression eqCrewId(Long crewId) {
+        return crewId != null ? crewScheduleEntity.crewId.eq(crewId) : null;
     }
 
     private BooleanExpression filterByDateOrMonth(LocalDate date, YearMonth yearMonth) {

--- a/src/main/java/com/youthexpedition/azit/modules/crew/application/port/out/LoadCrewSchedulePort.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/application/port/out/LoadCrewSchedulePort.java
@@ -18,8 +18,8 @@ public interface LoadCrewSchedulePort {
     List<CrewSchedule> findAllByMemberId(Long memberId);
     List<CrewSchedule> findAllTodaySchedulesByMemberId(Long memberId, LocalDateTime now);
     Optional<CrewSchedule> findNextClosestScheduleByMemberId(Long memberId, LocalDateTime now);
-    List<CrewSchedule> findAllByMemberIdAndMonth(Long memberId, YearMonth yearMonth, LocalDateTime now);
-    Map<LocalDate, Set<RunType>> findMyMonthlyAttendanceForCalendar(Long memberId, YearMonth yearMonth, LocalDateTime now);
+    List<CrewSchedule> findAllByMemberIdAndMonth(Long memberId, YearMonth yearMonth, LocalDateTime now, Long crewId);
+    Map<LocalDate, Set<RunType>> findMyMonthlyAttendanceForCalendar(Long memberId, YearMonth yearMonth, LocalDateTime now, Long crewId);
     boolean existsConflictingSchedule(Long memberId, LocalDateTime newMeetingAt, Long excludeScheduleId);
     List<CrewSchedule> findSchedulesToCancel(Long crewId, Long memberId, LocalDateTime now);
     List<CrewSchedule> findSchedulesToRemoveParticipant(Long crewId, Long memberId, LocalDateTime now);

--- a/src/main/java/com/youthexpedition/azit/modules/crew/application/service/CrewScheduleService.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/application/service/CrewScheduleService.java
@@ -446,7 +446,7 @@ public class CrewScheduleService implements CrewScheduleUseCase {
         LocalDateTime now = LocalDateTime.now();
 
         List<CrewSchedule> schedules = loadCrewSchedulePort.findAllByMemberIdAndMonth(
-                query.memberId(), query.yearMonth(), now);
+                query.memberId(), query.yearMonth(), now, query.crewId());
 
         List<MyAttendanceLogResponse.DailyAttendanceLog> attendanceLogs = crewScheduleResponseMapper.toDailyAttendanceLogs(schedules, query.memberId());
 
@@ -467,7 +467,7 @@ public class CrewScheduleService implements CrewScheduleUseCase {
         LocalDateTime now = LocalDateTime.now();
 
         Map<LocalDate, Set<RunType>> attendanceMap = loadCrewSchedulePort.findMyMonthlyAttendanceForCalendar(
-                query.memberId(), query.yearMonth(), now);
+                query.memberId(), query.yearMonth(), now, query.crewId());
 
         return crewScheduleResponseMapper.toMyAttendanceMonthlyListResponse(attendanceMap);
     }

--- a/src/main/java/com/youthexpedition/azit/modules/member/adapter/in/web/MemberController.java
+++ b/src/main/java/com/youthexpedition/azit/modules/member/adapter/in/web/MemberController.java
@@ -86,8 +86,10 @@ public class MemberController implements MemberControllerDocs {
 
     @GetMapping("/me/attendances")
     public CommonResponse<MyAttendanceLogResponse> getMyAttendanceLogs(
-            @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM") YearMonth yearMonth, @CurrentMemberId Long memberId) {
-        MyAttendanceMonthlyQuery query = MyAttendanceMonthlyQuery.of(yearMonth, memberId);
+            @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM") YearMonth yearMonth,
+            @RequestParam(required = false) Long crewId,
+            @CurrentMemberId Long memberId) {
+        MyAttendanceMonthlyQuery query = MyAttendanceMonthlyQuery.of(yearMonth, memberId, crewId);
         MyAttendanceLogResponse response = crewScheduleUseCase.getMyAttendanceLogs(query);
 
         return CommonResponse.of(CommonSuccessCode.SUCCESS, response);
@@ -95,8 +97,10 @@ public class MemberController implements MemberControllerDocs {
 
     @GetMapping("/me/attendances/calendar")
     public CommonResponse<List<MyAttendanceMonthlyListResponse>> getMyAttendancesForCalendar(
-            @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM") YearMonth yearMonth, @CurrentMemberId Long memberId) {
-        MyAttendanceMonthlyQuery query = MyAttendanceMonthlyQuery.of(yearMonth, memberId);
+            @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM") YearMonth yearMonth,
+            @RequestParam(required = false) Long crewId,
+            @CurrentMemberId Long memberId) {
+        MyAttendanceMonthlyQuery query = MyAttendanceMonthlyQuery.of(yearMonth, memberId, crewId);
         List<MyAttendanceMonthlyListResponse> response = crewScheduleUseCase.getMyAttendancesForCalendar(query);
 
         return CommonResponse.of(CommonSuccessCode.SUCCESS, response);

--- a/src/main/java/com/youthexpedition/azit/modules/member/adapter/in/web/docs/MemberControllerDocs.java
+++ b/src/main/java/com/youthexpedition/azit/modules/member/adapter/in/web/docs/MemberControllerDocs.java
@@ -161,10 +161,11 @@ public interface MemberControllerDocs {
             summary = "내 출석 로그 목록 조회",
             description = """
             사용자의 월별 출석 횟수, 누적 획득 포인트 및 상세 활동 이력을 조회합니다. <br>
-            
+
             **[쿼리 파라미터]** <br>
             * yearMonth (선택): 조회할 연월(yyyy-MM)입니다. 미입력 시 현재 시간 기준의 월을 조회합니다.<br>
-            
+            * crewId (선택): 특정 크루의 출석 이력만 필터링합니다. 미입력 시 전체 크루의 이력을 조회합니다.<br>
+
             **[참고 사항]** <br>
             * 아직 모임 시간이 지나지 않았고 출석도 하지 않은 예정 일정은 리스트에 나타나지 않습니다. <br>
             * 모임 시간이 이미 지난 일정(출석/결석 확정) 또는 모임 시간 전이라도 출석을 완료한 일정만 반환됩니다. <br><br>
@@ -176,6 +177,8 @@ public interface MemberControllerDocs {
     CommonResponse<MyAttendanceLogResponse> getMyAttendanceLogs(
             @Parameter(description = "조회 연월 (yyyy-MM)")
             @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM") YearMonth yearMonth,
+            @Parameter(description = "크루 ID (특정 크루 필터링, 미입력 시 전체)")
+            @RequestParam(required = false) Long crewId,
             @Parameter(hidden = true) @CurrentMemberId Long memberId
     );
 
@@ -184,19 +187,22 @@ public interface MemberControllerDocs {
             description = """
             특정 월의 날짜별 출석 상태(정기런/번개런)를 조회합니다. 신청한 일정이 하나라도 존재하는 날짜만 조회됩니다. <br>
             캘린더에서 각 날짜 하단에 상태 점을 표시하는 데 사용됩니다. <br><br>
-            
+
             **[쿼리 파라미터]** <br>
             * yearMonth (선택): 조회할 연월(yyyy-MM)입니다. 미입력 시 현재 시간 기준의 월을 조회합니다.<br>
-            
+            * crewId (선택): 특정 크루의 출석 이력만 필터링합니다. 미입력 시 전체 크루의 이력을 조회합니다.<br>
+
             **[참고 사항]** <br>
-                * 아직 모임 시간이 지나지 않았고 출석도 하지 않은 예정 일정은 리스트에 나타나지 않습니다. <br>
-                * 모임 시간이 이미 지난 일정(출석/결석 확정) 또는 모임 시간 전이라도 출석을 완료한 일정만 반환됩니다. <br><br>
+            * 아직 모임 시간이 지나지 않았고 출석도 하지 않은 예정 일정은 리스트에 나타나지 않습니다. <br>
+            * 모임 시간이 이미 지난 일정(출석/결석 확정) 또는 모임 시간 전이라도 출석을 완료한 일정만 반환됩니다. <br><br>
             """
     )
     CommonResponse<List<MyAttendanceMonthlyListResponse>> getMyAttendancesForCalendar(
+            @Parameter(description = "조회 연월 (yyyy-MM)")
             @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM") YearMonth yearMonth,
+            @Parameter(description = "크루 ID (특정 크루 필터링, 미입력 시 전체)")
+            @RequestParam(required = false) Long crewId,
             @Parameter(hidden = true) @CurrentMemberId Long memberId
-
     );
 
     @Operation(

--- a/src/main/java/com/youthexpedition/azit/modules/member/application/port/query/MyAttendanceMonthlyQuery.java
+++ b/src/main/java/com/youthexpedition/azit/modules/member/application/port/query/MyAttendanceMonthlyQuery.java
@@ -4,12 +4,14 @@ import java.time.YearMonth;
 
 public record MyAttendanceMonthlyQuery(
         YearMonth yearMonth,
-        Long memberId
+        Long memberId,
+        Long crewId
 ) {
-    public static MyAttendanceMonthlyQuery of(YearMonth yearMonth, Long memberId) {
+    public static MyAttendanceMonthlyQuery of(YearMonth yearMonth, Long memberId, Long crewId) {
         return new MyAttendanceMonthlyQuery(
                 yearMonth != null ? yearMonth : YearMonth.now(),
-                memberId
+                memberId,
+                crewId
         );
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈
- #174

## ✨ 작업 내용
> 이번 PR에서 변경된 핵심 내용을 요약해주세요.

- 출석 로그 크루 필터링
- GET /me/attendances, GET /me/attendances/calendar 모두 crewId 옵셔널 파라미터 추가

## 🧱 아키텍처 변경 요약
> 이번 작업으로 인해 변경된 주요 흐름을 적어주세요. (없으면 생략 가능)

- 예: 신규 UseCase 추가 및 외부 API 연동 어댑터 구현

## 📸 스크린샷 (선택 사항)
> API 테스트 결과 등을 첨부해주세요.


## ⚠️ 주의 사항 (선택)
- [ ] DB 스키마 변경이 있나요?
- [x] API 명세(Swagger)가 업데이트 되었나요?
- [ ] 새로운 환경 변수(.env)가 추가 되었나요?

## ✅ 셀프 체크리스트
- [ ] 브랜치 전략(develop)에 맞게 올렸나요?
- [ ] 커밋 컨벤션을 준수했나요?
- [ ] 불필요한 주석이나 print문은 제거했나요?
- [ ] 로컬에서 테스트는 성공했나요?