### PR TITLE
[FEAT] 크루 해산하기 API 구현

### DIFF
--- a/src/main/java/com/youthexpedition/azit/modules/crew/adapter/in/web/CrewController.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/adapter/in/web/CrewController.java
@@ -122,4 +122,11 @@ public class CrewController implements CrewControllerDocs {
 
         return CommonResponse.of(CommonSuccessCode.SUCCESS);
     }
+
+    @DeleteMapping("/{crewId}")
+    public CommonResponse<Void> dissolveCrew(@PathVariable Long crewId, @CurrentMemberId Long memberId) {
+        crewUseCase.dissolveCrew(crewId, memberId);
+
+        return CommonResponse.of(CommonSuccessCode.SUCCESS);
+    }
 }

--- a/src/main/java/com/youthexpedition/azit/modules/crew/adapter/in/web/docs/CrewControllerDocs.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/adapter/in/web/docs/CrewControllerDocs.java
@@ -272,4 +272,28 @@ public interface CrewControllerDocs {
             @PathVariable Long crewId,
             @Parameter(hidden = true) @CurrentMemberId Long memberId,
             @Valid @RequestBody UpdateCrewProfileRequest request);
+
+    @Operation(
+            summary = "크루 해산",
+            description = """
+            리더가 크루를 영구적으로 해산합니다. <br><br>
+
+            **[해산 처리 내용]** <br>
+            * 미래 ACTIVE 일정이 모두 CANCELLED 처리됩니다. <br>
+            * 정회원(JOINED) 전원이 EXITED 처리됩니다. <br>
+            * 크루 인원 수가 0으로 초기화되고 상태가 DISSOLVED로 변경됩니다. <br>
+            * 과거 일정 및 출석 로그는 보존됩니다. <br><br>
+
+            **[제약 사항]** <br>
+            * 크루 리더만 해산을 요청할 수 있습니다. (NOT_CREW_LEADER)
+            * 이미 해산된 크루는 재해산이 불가합니다. (CREW_ALREADY_DISSOLVED)
+            """
+    )
+    @ApiErrorCodeExamples({
+            "CREW_NOT_FOUND", "NOT_A_CREW_MEMBER", "NOT_CREW_LEADER", "CREW_ALREADY_DISSOLVED",
+            "UNAUTHORIZED", "EXPIRED_TOKEN", "INVALID_TOKEN", "TOKEN_REUSE_DETECTED", "BLACKLISTED_TOKEN"
+    })
+    CommonResponse<Void> dissolveCrew(
+            @PathVariable Long crewId,
+            @Parameter(hidden = true) @CurrentMemberId Long memberId);
 }

--- a/src/main/java/com/youthexpedition/azit/modules/crew/adapter/in/web/docs/CrewControllerDocs.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/adapter/in/web/docs/CrewControllerDocs.java
@@ -278,7 +278,7 @@ public interface CrewControllerDocs {
             description = """
             리더가 크루를 영구적으로 해산합니다. <br><br>
 
-            **[해산 처리 내용]** <br>
+            **[처리 내용]** <br>
             * 미래 ACTIVE 일정이 모두 CANCELLED 처리됩니다. <br>
             * 정회원(JOINED) 전원이 EXITED 처리됩니다. <br>
             * 크루 인원 수가 0으로 초기화되고 상태가 DISSOLVED로 변경됩니다. <br>

--- a/src/main/java/com/youthexpedition/azit/modules/crew/adapter/in/web/docs/CrewControllerDocs.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/adapter/in/web/docs/CrewControllerDocs.java
@@ -241,7 +241,7 @@ public interface CrewControllerDocs {
             summary = "크루 프로필 수정",
             description = """
                     크루 프로필을 수정합니다. <br><br>
-                        
+                    
                     **[크루 이미지 URL 제약 사항]** <br>
                     크루 이미지 URL은 아래 세 가지 중 하나여야 합니다.<br>
                     1. temp 경로가 포함된 CloudFront URL (새 커스텀 이미지 적용 시)<br>

--- a/src/main/java/com/youthexpedition/azit/modules/crew/adapter/in/web/docs/CrewControllerDocs.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/adapter/in/web/docs/CrewControllerDocs.java
@@ -158,7 +158,7 @@ public interface CrewControllerDocs {
 
                     **[제약 사항]** <br>
                     * 가입 신청(REQUESTED) 상태인 경우에만 취소가 가능합니다. (JOIN_REQUEST_NOT_FOUND) <br>
-                    * 취소 후 24시간 이내에는 동일 크루에 재신청이 불가합니다. (CANCEL_REJOINING_COOLDOWN)
+                    * 취소 후 1시간 이내에는 동일 크루에 재신청이 불가합니다. (CANCEL_REJOINING_COOLDOWN)
                     """
     )
     @ApiErrorCodeExamples({

--- a/src/main/java/com/youthexpedition/azit/modules/crew/adapter/out/persistence/CrewMemberPersistenceAdapter.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/adapter/out/persistence/CrewMemberPersistenceAdapter.java
@@ -101,4 +101,11 @@ public class CrewMemberPersistenceAdapter implements LoadCrewMemberPort, SaveCre
                 .map(crewMemberMapper::toDomain)
                 .collect(Collectors.toMap(CrewMember::getMemberId, cm -> cm));
     }
+
+    @Override
+    public List<CrewMember> findAllJoinedByCrewId(Long crewId) {
+        return crewMemberRepository.findByCrew_IdAndStatus(crewId, CrewMemberStatus.JOINED).stream()
+                .map(crewMemberMapper::toDomain)
+                .toList();
+    }
 }

--- a/src/main/java/com/youthexpedition/azit/modules/crew/adapter/out/persistence/CrewMemberPersistenceAdapter.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/adapter/out/persistence/CrewMemberPersistenceAdapter.java
@@ -103,8 +103,8 @@ public class CrewMemberPersistenceAdapter implements LoadCrewMemberPort, SaveCre
     }
 
     @Override
-    public List<CrewMember> findAllJoinedByCrewId(Long crewId) {
-        return crewMemberRepository.findByCrew_IdAndStatus(crewId, CrewMemberStatus.JOINED).stream()
+    public List<CrewMember> findAllActiveByCrewId(Long crewId) {
+        return crewMemberRepository.findByCrew_IdAndStatusIn(crewId, PARTICIPATING_STATUSES).stream()
                 .map(crewMemberMapper::toDomain)
                 .toList();
     }

--- a/src/main/java/com/youthexpedition/azit/modules/crew/adapter/out/persistence/CrewSchedulePersistenceAdapter.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/adapter/out/persistence/CrewSchedulePersistenceAdapter.java
@@ -124,4 +124,11 @@ public class CrewSchedulePersistenceAdapter implements LoadCrewSchedulePort, Sav
                 .map(crewScheduleMapper::toDomain)
                 .toList();
     }
+
+    @Override
+    public List<CrewSchedule> findActiveSchedulesByCrewId(Long crewId, LocalDateTime now) {
+        return crewScheduleRepository.findActiveSchedulesByCrewId(crewId, now).stream()
+                .map(crewScheduleMapper::toDomain)
+                .toList();
+    }
 }

--- a/src/main/java/com/youthexpedition/azit/modules/crew/adapter/out/persistence/repository/CrewMemberRepository.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/adapter/out/persistence/repository/CrewMemberRepository.java
@@ -16,5 +16,5 @@ public interface CrewMemberRepository extends JpaRepository<CrewMemberEntity, Lo
     List<CrewMemberEntity> findAllByMemberId(Long memberId);
     List<CrewMemberEntity> findAllByMemberIdAndStatusIn(Long memberId, Collection<CrewMemberStatus> statuses);
     List<CrewMemberEntity> findByCrew_IdAndMemberIdIn(Long crewId, List<Long> memberIds);
-    List<CrewMemberEntity> findByCrew_IdAndStatus(Long crewId, CrewMemberStatus status);
+    List<CrewMemberEntity> findByCrew_IdAndStatusIn(Long crewId, Collection<CrewMemberStatus> statuses);
 }

--- a/src/main/java/com/youthexpedition/azit/modules/crew/adapter/out/persistence/repository/CrewMemberRepository.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/adapter/out/persistence/repository/CrewMemberRepository.java
@@ -16,4 +16,5 @@ public interface CrewMemberRepository extends JpaRepository<CrewMemberEntity, Lo
     List<CrewMemberEntity> findAllByMemberId(Long memberId);
     List<CrewMemberEntity> findAllByMemberIdAndStatusIn(Long memberId, Collection<CrewMemberStatus> statuses);
     List<CrewMemberEntity> findByCrew_IdAndMemberIdIn(Long crewId, List<Long> memberIds);
+    List<CrewMemberEntity> findByCrew_IdAndStatus(Long crewId, CrewMemberStatus status);
 }

--- a/src/main/java/com/youthexpedition/azit/modules/crew/adapter/out/persistence/repository/CrewScheduleRepositoryCustom.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/adapter/out/persistence/repository/CrewScheduleRepositoryCustom.java
@@ -22,4 +22,5 @@ public interface CrewScheduleRepositoryCustom {
     boolean existsConflictingSchedule(Long memberId, LocalDateTime newMeetingAt, Long excludeScheduleId);
     List<CrewScheduleEntity> findSchedulesToCancelByCreator(Long crewId, Long memberId, LocalDateTime now);
     List<CrewScheduleEntity> findSchedulesToRemoveParticipant(Long crewId, Long memberId, LocalDateTime now);
+    List<CrewScheduleEntity> findActiveSchedulesByCrewId(Long crewId, LocalDateTime now);
 }

--- a/src/main/java/com/youthexpedition/azit/modules/crew/adapter/out/persistence/repository/CrewScheduleRepositoryImpl.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/adapter/out/persistence/repository/CrewScheduleRepositoryImpl.java
@@ -195,6 +195,17 @@ public class CrewScheduleRepositoryImpl implements CrewScheduleRepositoryCustom 
                 .fetch();
     }
 
+    @Override
+    public List<CrewScheduleEntity> findActiveSchedulesByCrewId(Long crewId, LocalDateTime now) {
+        return queryFactory.selectFrom(crewScheduleEntity)
+                .where(
+                        crewScheduleEntity.crewId.eq(crewId),
+                        crewScheduleEntity.status.eq(ScheduleStatus.ACTIVE),
+                        crewScheduleEntity.meetingAt.gt(now) // 아직 시작하지 않은 일정만
+                )
+                .fetch();
+    }
+
     private BooleanExpression eqDate(LocalDate date) {
         if (date == null) return null;
         // LocalDateTime의 시작(00:00:00)과 끝(23:59:59) 사이 조회

--- a/src/main/java/com/youthexpedition/azit/modules/crew/application/port/in/CrewUseCase.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/application/port/in/CrewUseCase.java
@@ -25,4 +25,5 @@ public interface CrewUseCase {
     InvitationCodeResponse regenerateInvitationCode(Long crewId, Long memberId);
     void updateCrewProfile(Long crewId, Long memberId, UpdateCrewProfileCommand command);
     CrewInfoResponse getCrewInfo(Long crewId, Long memberId);
+    void dissolveCrew(Long crewId, Long leaderId);
 }

--- a/src/main/java/com/youthexpedition/azit/modules/crew/application/port/out/LoadCrewMemberPort.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/application/port/out/LoadCrewMemberPort.java
@@ -22,5 +22,5 @@ public interface LoadCrewMemberPort {
     List<CrewMember> findAllByMemberId(Long memberId);
     List<CrewMember> findAllActiveByMemberId(Long memberId);
     Map<Long, CrewMember> findAllByCrewIdAndMemberIds(Long crewId, List<Long> memberIds);
-    List<CrewMember> findAllJoinedByCrewId(Long crewId);
+    List<CrewMember> findAllActiveByCrewId(Long crewId); // JOINED + REQUESTED
 }

--- a/src/main/java/com/youthexpedition/azit/modules/crew/application/port/out/LoadCrewMemberPort.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/application/port/out/LoadCrewMemberPort.java
@@ -22,4 +22,5 @@ public interface LoadCrewMemberPort {
     List<CrewMember> findAllByMemberId(Long memberId);
     List<CrewMember> findAllActiveByMemberId(Long memberId);
     Map<Long, CrewMember> findAllByCrewIdAndMemberIds(Long crewId, List<Long> memberIds);
+    List<CrewMember> findAllJoinedByCrewId(Long crewId);
 }

--- a/src/main/java/com/youthexpedition/azit/modules/crew/application/port/out/LoadCrewSchedulePort.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/application/port/out/LoadCrewSchedulePort.java
@@ -23,5 +23,5 @@ public interface LoadCrewSchedulePort {
     boolean existsConflictingSchedule(Long memberId, LocalDateTime newMeetingAt, Long excludeScheduleId);
     List<CrewSchedule> findSchedulesToCancel(Long crewId, Long memberId, LocalDateTime now);
     List<CrewSchedule> findSchedulesToRemoveParticipant(Long crewId, Long memberId, LocalDateTime now);
-
+    List<CrewSchedule> findActiveSchedulesByCrewId(Long crewId, LocalDateTime now);
 }

--- a/src/main/java/com/youthexpedition/azit/modules/crew/application/service/CrewService.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/application/service/CrewService.java
@@ -384,16 +384,22 @@ public class CrewService implements CrewUseCase {
             log.info("[CREW] crewId: {} 해산으로 인해 ACTIVE 일정 {}건을 취소합니다.", crewId, activeSchedules.size());
         }
 
-        // 회원 전원 EXITED 처리
-        List<CrewMember> joinedMembers = loadCrewMemberPort.findAllJoinedByCrewId(crewId);
-        if (!joinedMembers.isEmpty()) {
-            joinedMembers.forEach(member -> member.exit(now));
-            saveCrewMemberPort.saveAll(joinedMembers);
-            log.info("[CREW] crewId: {} 해산으로 인해 모든 회원을 {}명을 EXITED 처리합니다.", crewId, joinedMembers.size());
+        // JOINED + REQUESTED 상태인 멤버 일괄 처리
+        List<CrewMember> activeMembers = loadCrewMemberPort.findAllActiveByCrewId(crewId);
+        if (!activeMembers.isEmpty()) {
+            activeMembers.forEach(member -> {
+                if (member.getStatus() == CrewMemberStatus.JOINED) {
+                    member.exit(now);       // 정회원 → EXITED
+                } else {
+                    member.cancel(now);     // 가입대기 → CANCELLED
+                }
+            });
+            saveCrewMemberPort.saveAll(activeMembers);
+            log.info("[CREW] crewId: {} 해산합니다.", crewId);
         }
 
         // 크루 해산
-        crew.dissolve();
+        crew.dissolve(now);
         saveCrewPort.save(crew);
         log.info("[CREW] crewId: {} 가 해산되었습니다. leaderId: {}", crewId, leaderId);
     }

--- a/src/main/java/com/youthexpedition/azit/modules/crew/application/service/CrewService.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/application/service/CrewService.java
@@ -14,13 +14,16 @@ import com.youthexpedition.azit.modules.crew.application.port.in.dto.*;
 import com.youthexpedition.azit.modules.crew.application.port.in.dto.CrewInfoResponse;
 import com.youthexpedition.azit.modules.crew.application.port.out.LoadCrewMemberPort;
 import com.youthexpedition.azit.modules.crew.application.port.out.LoadCrewPort;
+import com.youthexpedition.azit.modules.crew.application.port.out.LoadCrewSchedulePort;
 import com.youthexpedition.azit.modules.crew.application.port.out.SaveCrewMemberPort;
 import com.youthexpedition.azit.modules.crew.application.port.out.SaveCrewPort;
+import com.youthexpedition.azit.modules.crew.application.port.out.SaveCrewSchedulePort;
 import com.youthexpedition.azit.modules.crew.application.port.out.query.CrewMemberInfoDto;
 import com.youthexpedition.azit.modules.crew.application.service.mapper.CrewMemberResponseMapper;
 import com.youthexpedition.azit.modules.crew.application.service.mapper.CrewResponseMapper;
 import com.youthexpedition.azit.modules.crew.domain.model.Crew;
 import com.youthexpedition.azit.modules.crew.domain.model.CrewMember;
+import com.youthexpedition.azit.modules.crew.domain.model.CrewSchedule;
 import com.youthexpedition.azit.modules.crew.domain.model.enums.CrewErrorCode;
 import com.youthexpedition.azit.modules.crew.domain.model.enums.CrewMemberRole;
 import com.youthexpedition.azit.modules.crew.domain.model.enums.CrewMemberStatus;
@@ -47,6 +50,8 @@ public class CrewService implements CrewUseCase {
     private final LoadCrewPort loadCrewPort;
     private final SaveCrewMemberPort saveCrewMemberPort;
     private final LoadCrewMemberPort loadCrewMemberPort;
+    private final LoadCrewSchedulePort loadCrewSchedulePort;
+    private final SaveCrewSchedulePort saveCrewSchedulePort;
     private final CrewScheduleUseCase crewScheduleUseCase;
     private final CrewMemberResponseMapper crewMemberResponseMapper;
     private final CrewResponseMapper crewResponseMapper;
@@ -353,6 +358,44 @@ public class CrewService implements CrewUseCase {
         validateMember(crewId, memberId);
 
         return crewResponseMapper.toCrewInfoResponse(crew);
+    }
+
+    @Override
+    @Transactional
+    public void dissolveCrew(Long crewId, Long leaderId) {
+        Crew crew = loadCrewPort.findById(crewId)
+                .orElseThrow(() -> new BusinessException(CrewErrorCode.CREW_NOT_FOUND));
+
+        // 이미 해산된 크루인지 확인
+        if (crew.isDissolved()) {
+            throw new BusinessException(CrewErrorCode.CREW_ALREADY_DISSOLVED);
+        }
+
+        // 리더 권한 확인
+        validateLeader(crewId, leaderId);
+
+        LocalDateTime now = LocalDateTime.now();
+
+        // 미래 ACTIVE 일정 전체 취소
+        List<CrewSchedule> activeSchedules = loadCrewSchedulePort.findActiveSchedulesByCrewId(crewId, now);
+        if (!activeSchedules.isEmpty()) {
+            activeSchedules.forEach(CrewSchedule::cancel);
+            saveCrewSchedulePort.saveAll(activeSchedules);
+            log.info("[CREW] crewId: {} 해산으로 인해 ACTIVE 일정 {}건을 취소합니다.", crewId, activeSchedules.size());
+        }
+
+        // 회원 전원 EXITED 처리
+        List<CrewMember> joinedMembers = loadCrewMemberPort.findAllJoinedByCrewId(crewId);
+        if (!joinedMembers.isEmpty()) {
+            joinedMembers.forEach(member -> member.exit(now));
+            saveCrewMemberPort.saveAll(joinedMembers);
+            log.info("[CREW] crewId: {} 해산으로 인해 모든 회원을 {}명을 EXITED 처리합니다.", crewId, joinedMembers.size());
+        }
+
+        // 크루 해산
+        crew.dissolve();
+        saveCrewPort.save(crew);
+        log.info("[CREW] crewId: {} 가 해산되었습니다. leaderId: {}", crewId, leaderId);
     }
 
     // 리더 여부 체크

--- a/src/main/java/com/youthexpedition/azit/modules/crew/domain/model/Crew.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/domain/model/Crew.java
@@ -66,6 +66,17 @@ public class Crew {
         }
     }
 
+    // 크루 해산
+    public void dissolve() {
+        this.memberCount = 0;
+        this.status = CrewStatus.DISSOLVED;
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public boolean isDissolved() {
+        return this.status == CrewStatus.DISSOLVED;
+    }
+
     // 초대 코드 재발급
     public void updateInvitationCode(String invitationCode) {
         this.invitationCode = invitationCode;

--- a/src/main/java/com/youthexpedition/azit/modules/crew/domain/model/Crew.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/domain/model/Crew.java
@@ -67,10 +67,10 @@ public class Crew {
     }
 
     // 크루 해산
-    public void dissolve() {
+    public void dissolve(LocalDateTime now) {
         this.memberCount = 0;
         this.status = CrewStatus.DISSOLVED;
-        this.updatedAt = LocalDateTime.now();
+        this.updatedAt = now;
     }
 
     public boolean isDissolved() {

--- a/src/main/java/com/youthexpedition/azit/modules/crew/domain/model/CrewMember.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/domain/model/CrewMember.java
@@ -24,6 +24,7 @@ public class CrewMember {
     private LocalDateTime updatedAt;
 
     private static final long REJOINING_COOLDOWN_HOURS = 24;
+    private static final long CANCEL_COOLDOWN_HOURS = 1;
 
     // 리더 등록
     public static CrewMember createAsLeader(Long crewId, Long memberId) {
@@ -90,10 +91,10 @@ public class CrewMember {
         this.cancelledAt = cancelledAt;
     }
 
-    // 취소 후 재신청 쿨다운 여부 확인 (24시간)
+    // 취소 후 재신청 쿨다운 여부 확인 (1시간)
     public boolean isCancelCooldownActive(LocalDateTime now) {
         if (this.cancelledAt == null) return false;
-        return this.cancelledAt.plusHours(REJOINING_COOLDOWN_HOURS).isAfter(now);
+        return this.cancelledAt.plusHours(CANCEL_COOLDOWN_HOURS).isAfter(now);
     }
 
     // 가입 재신청

--- a/src/main/java/com/youthexpedition/azit/modules/crew/domain/model/enums/CrewErrorCode.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/domain/model/enums/CrewErrorCode.java
@@ -24,7 +24,7 @@ public enum CrewErrorCode implements BaseErrorCode {
     CANNOT_SERVICE_WITHDRAW_AS_LEADER("CANNOT_SERVICE_WITHDRAW_AS_LEADER", "리더로 활동 중인 크루가 있습니다. 권한을 위임하거나 크루를 해산한 후 서비스를 탈퇴할 수 있습니다.", HttpStatus.BAD_REQUEST),
     EXPELLED_REJOINING_COOLDOWN("EXPELLED_REJOINING_COOLDOWN", "방출 후 24시간이 지나지 않아 재가입 요청이 불가합니다.", HttpStatus.BAD_REQUEST),
     EXIT_REJOINING_COOLDOWN("EXIT_REJOINING_COOLDOWN", "탈퇴 후 24시간이 지나지 않아 재가입 요청이 불가합니다.", HttpStatus.BAD_REQUEST),
-    CANCEL_REJOINING_COOLDOWN("CANCEL_REJOINING_COOLDOWN", "가입 신청 취소 후 24시간이 지나지 않아 재가입 요청이 불가합니다.", HttpStatus.BAD_REQUEST),
+    CANCEL_REJOINING_COOLDOWN("CANCEL_REJOINING_COOLDOWN", "가입 신청 취소 후 1시간이 지나지 않아 재신청이 불가합니다.", HttpStatus.BAD_REQUEST),
     CREW_JOIN_LIMIT_EXCEEDED("CREW_JOIN_LIMIT_EXCEEDED", "최대 3개의 크루까지 가입할 수 있습니다.", HttpStatus.BAD_REQUEST),
     CREW_ALREADY_DISSOLVED("CREW_ALREADY_DISSOLVED", "이미 해산된 크루입니다.", HttpStatus.BAD_REQUEST),
 

--- a/src/main/java/com/youthexpedition/azit/modules/crew/domain/model/enums/CrewErrorCode.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/domain/model/enums/CrewErrorCode.java
@@ -26,6 +26,7 @@ public enum CrewErrorCode implements BaseErrorCode {
     EXIT_REJOINING_COOLDOWN("EXIT_REJOINING_COOLDOWN", "탈퇴 후 24시간이 지나지 않아 재가입 요청이 불가합니다.", HttpStatus.BAD_REQUEST),
     CANCEL_REJOINING_COOLDOWN("CANCEL_REJOINING_COOLDOWN", "가입 신청 취소 후 24시간이 지나지 않아 재가입 요청이 불가합니다.", HttpStatus.BAD_REQUEST),
     CREW_JOIN_LIMIT_EXCEEDED("CREW_JOIN_LIMIT_EXCEEDED", "최대 3개의 크루까지 가입할 수 있습니다.", HttpStatus.BAD_REQUEST),
+    CREW_ALREADY_DISSOLVED("CREW_ALREADY_DISSOLVED", "이미 해산된 크루입니다.", HttpStatus.BAD_REQUEST),
 
     // 일정 관련
     INVALID_SCHEDULE_TIME("INVALID_SCHEDULE_TIME", "유효하지 않은 일정 시간입니다.", HttpStatus.BAD_REQUEST),

--- a/src/main/java/com/youthexpedition/azit/modules/crew/domain/model/enums/CrewStatus.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/domain/model/enums/CrewStatus.java
@@ -1,5 +1,5 @@
 package com.youthexpedition.azit.modules.crew.domain.model.enums;
 
 public enum CrewStatus {
-    ACTIVE, INACTIVE
+    ACTIVE, INACTIVE, DISSOLVED
 }

--- a/src/test/java/com/youthexpedition/azit/modules/crew/application/service/CrewServiceTest.java
+++ b/src/test/java/com/youthexpedition/azit/modules/crew/application/service/CrewServiceTest.java
@@ -182,7 +182,7 @@ class CrewServiceTest {
         }
 
         @Test
-        @DisplayName("실패: 취소(CANCELLED) 후 24시간 이내에 재신청하면 CANCEL_REJOINING_COOLDOWN 예외가 발생한다.")
+        @DisplayName("실패: 취소(CANCELLED) 후 1시간 이내에 재신청하면 CANCEL_REJOINING_COOLDOWN 예외가 발생한다.")
         void joinCrew_Fail_CancelCooldown() {
             // given
             Long crewId = 100L;
@@ -197,7 +197,7 @@ class CrewServiceTest {
                     .crewId(crewId)
                     .memberId(memberId)
                     .status(CrewMemberStatus.CANCELLED)
-                    .cancelledAt(LocalDateTime.now().minusHours(1)) // 1시간 전 취소 (쿨다운 중)
+                    .cancelledAt(LocalDateTime.now().minusMinutes(30)) // 30분 전 취소 (쿨다운 중)
                     .build();
             given(loadCrewMemberPort.findByCrewIdAndMemberId(crewId, memberId)).willReturn(Optional.of(cancelledMember));
 


### PR DESCRIPTION
## 📌 관련 이슈
- #174

## ✨ 작업 내용
> 이번 PR에서 변경된 핵심 내용을 요약해주세요.

- 크루 해산하기 API 구현
- 가입 신청 취소 시 쿨다운 1시간으로 변경

## 🧱 아키텍처 변경 요약
> 이번 작업으로 인해 변경된 주요 흐름을 적어주세요. (없으면 생략 가능)

- 예: 신규 UseCase 추가 및 외부 API 연동 어댑터 구현

## 📸 스크린샷 (선택 사항)
> API 테스트 결과 등을 첨부해주세요.

## ⚠️ 주의 사항 (선택)
- [ ] DB 스키마 변경이 있나요?
- [x] API 명세(Swagger)가 업데이트 되었나요?
- [ ] 새로운 환경 변수(.env)가 추가 되었나요?

## ✅ 셀프 체크리스트
- [ ] 브랜치 전략(develop)에 맞게 올렸나요?
- [ ] 커밋 컨벤션을 준수했나요?
- [ ] 불필요한 주석이나 print문은 제거했나요?
- [ ] 로컬에서 테스트는 성공했나요?