### PR TITLE
[FEAT] 프론트엔드 테스트용 약관 동의 전 상태 변경 API 구현

### DIFF
--- a/src/main/java/com/youthexpedition/azit/modules/member/adapter/in/web/MemberController.java
+++ b/src/main/java/com/youthexpedition/azit/modules/member/adapter/in/web/MemberController.java
@@ -119,4 +119,11 @@ public class MemberController implements MemberControllerDocs {
 
         return CommonResponse.of(CommonSuccessCode.SUCCESS);
     }
+
+    @PostMapping("/me/reset-to-pending-terms")
+    public CommonResponse<Void> resetToPendingTerms(@CurrentMemberId Long memberId) {
+        memberUseCase.resetToPendingTerms(memberId);
+
+        return CommonResponse.of(CommonSuccessCode.SUCCESS);
+    }
 }

--- a/src/main/java/com/youthexpedition/azit/modules/member/adapter/in/web/docs/MemberControllerDocs.java
+++ b/src/main/java/com/youthexpedition/azit/modules/member/adapter/in/web/docs/MemberControllerDocs.java
@@ -268,7 +268,6 @@ public interface MemberControllerDocs {
                     **[처리 내용]** <br>
                     * 회원 상태를 PENDING_TERMS로 변경합니다. <br>
                     * 필수 약관 동의 시각, 마케팅·알림 수신 동의 정보를 초기화합니다. <br><br>
-                    * 가입되어 있던 모든 크루를 탈퇴합니다. <br>
                     """
     )
     @ApiErrorCodeExamples({

--- a/src/main/java/com/youthexpedition/azit/modules/member/adapter/in/web/docs/MemberControllerDocs.java
+++ b/src/main/java/com/youthexpedition/azit/modules/member/adapter/in/web/docs/MemberControllerDocs.java
@@ -257,4 +257,22 @@ public interface MemberControllerDocs {
             "UNAUTHORIZED", "EXPIRED_TOKEN", "INVALID_TOKEN", "TOKEN_REUSE_DETECTED", "BLACKLISTED_TOKEN"
     })
     CommonResponse<LinkedProviderResponse> getLinkedProviders(@Parameter(hidden = true) @CurrentMemberId Long memberId);
+
+    @Operation(
+            summary = "[테스트용] 약관 동의 전 상태로 초기화",
+            description = """
+                    **프론트엔드 테스트 전용 API입니다. 운영 환경에서는 사용하지 않습니다.** <br><br>
+
+                    현재 로그인한 회원의 상태를 약관 동의 전(PENDING_TERMS)으로 초기화합니다. <br><br>
+
+                    **[처리 내용]** <br>
+                    * 회원 상태를 PENDING_TERMS로 변경합니다. <br>
+                    * 필수 약관 동의 시각, 마케팅·알림 수신 동의 정보를 초기화합니다. <br><br>
+                    * 가입되어 있던 모든 크루를 탈퇴합니다. <br>
+                    """
+    )
+    @ApiErrorCodeExamples({
+            "MEMBER_NOT_FOUND", "UNAUTHORIZED", "EXPIRED_TOKEN", "INVALID_TOKEN", "TOKEN_REUSE_DETECTED", "BLACKLISTED_TOKEN"
+    })
+    CommonResponse<Void> resetToPendingTerms(@Parameter(hidden = true) @CurrentMemberId Long memberId);
 }

--- a/src/main/java/com/youthexpedition/azit/modules/member/application/port/in/MemberUseCase.java
+++ b/src/main/java/com/youthexpedition/azit/modules/member/application/port/in/MemberUseCase.java
@@ -18,4 +18,5 @@ public interface MemberUseCase {
     List<MyCrewResponse> getMyCrews(Long memberId);
     void updateMemberProfile(Long memberId, UpdateMemberProfileCommand command);
     LinkedProviderResponse getLinkedProviders(Long memberId);
+    void resetToPendingTerms(Long memberId);
 }

--- a/src/main/java/com/youthexpedition/azit/modules/member/application/service/MemberService.java
+++ b/src/main/java/com/youthexpedition/azit/modules/member/application/service/MemberService.java
@@ -1,5 +1,6 @@
 package com.youthexpedition.azit.modules.member.application.service;
 
+import com.youthexpedition.azit.infrastructure.common.util.image.ImageUpdateUtil;
 import com.youthexpedition.azit.infrastructure.exception.BusinessException;
 import com.youthexpedition.azit.modules.auth.application.port.in.command.SocialRevokeCommand;
 import com.youthexpedition.azit.modules.auth.application.port.out.SocialAuthPort;
@@ -14,7 +15,6 @@ import com.youthexpedition.azit.modules.crew.domain.model.enums.CrewErrorCode;
 import com.youthexpedition.azit.modules.crew.domain.model.enums.CrewMemberRole;
 import com.youthexpedition.azit.modules.crew.domain.model.enums.CrewMemberStatus;
 import com.youthexpedition.azit.modules.member.application.port.in.MemberUseCase;
-import com.youthexpedition.azit.infrastructure.common.util.image.ImageUpdateUtil;
 import com.youthexpedition.azit.modules.member.application.port.in.command.AgreeToTermsCommand;
 import com.youthexpedition.azit.modules.member.application.port.in.command.UpdateMemberProfileCommand;
 import com.youthexpedition.azit.modules.member.application.port.in.dto.LinkedProviderResponse;
@@ -192,6 +192,17 @@ public class MemberService implements MemberUseCase {
         // 이미지 업데이트
         imageUpdateUtil.update(command.imageUrl(), member.getProfileImageUrl(), memberId, true, member::updateProfileImageUrl);
 
+        saveMemberPort.save(member);
+    }
+
+    @Override
+    public void resetToPendingTerms(Long memberId) {
+        Member member = getMember(memberId);
+
+        member.resetToPendingTerms();
+
+        // 가입한 크루 인원 수 차감 및 상태 변경
+        processCrewWithdrawal(memberId);
         saveMemberPort.save(member);
     }
 

--- a/src/main/java/com/youthexpedition/azit/modules/member/application/service/MemberService.java
+++ b/src/main/java/com/youthexpedition/azit/modules/member/application/service/MemberService.java
@@ -200,9 +200,6 @@ public class MemberService implements MemberUseCase {
         Member member = getMember(memberId);
 
         member.resetToPendingTerms();
-
-        // 가입한 크루 인원 수 차감 및 상태 변경
-        processCrewWithdrawal(memberId);
         saveMemberPort.save(member);
     }
 

--- a/src/main/java/com/youthexpedition/azit/modules/member/domain/model/Member.java
+++ b/src/main/java/com/youthexpedition/azit/modules/member/domain/model/Member.java
@@ -86,6 +86,16 @@ public class Member {
         this.appleRefreshToken = null;
     }
 
+    // [테스트용] 약관 동의 전 상태로 초기화
+    public void resetToPendingTerms() {
+        this.status = MemberStatus.PENDING_TERMS;
+        this.essentialTermsAgreedAt = null;
+        this.isMarketingTermsAgreed = false;
+        this.marketingTermsAgreedAt = null;
+        this.isNotificationAgreed = false;
+        this.notificationAgreedAt = null;
+    }
+
     // 탈퇴 상태에서 재로그인 할 경우 ACTIVE 처리
     public void reactivate() {
         if (this.status != MemberStatus.WITHDRAWN) {


### PR DESCRIPTION
## 📌 관련 이슈
- #이슈번호 (예: #1)

## ✨ 작업 내용
> 이번 PR에서 변경된 핵심 내용을 요약해주세요.

- 약관 동의 전 상태 변경 API

## 🧱 아키텍처 변경 요약
> 이번 작업으로 인해 변경된 주요 흐름을 적어주세요. (없으면 생략 가능)

- 예: 신규 UseCase 추가 및 외부 API 연동 어댑터 구현

## 📸 스크린샷 (선택 사항)
> API 테스트 결과 등을 첨부해주세요.

## ⚠️ 주의 사항 (선택)
- [ ] DB 스키마 변경이 있나요?
- [ ] API 명세(Swagger)가 업데이트 되었나요?
- [ ] 새로운 환경 변수(.env)가 추가 되었나요?

## ✅ 셀프 체크리스트
- [ ] 브랜치 전략(develop)에 맞게 올렸나요?
- [ ] 커밋 컨벤션을 준수했나요?
- [ ] 불필요한 주석이나 print문은 제거했나요?
- [ ] 로컬에서 테스트는 성공했나요?