### PR TITLE
[FEAT] 프론트엔드 테스트용 즉시 탈퇴 API 구현

### DIFF
--- a/src/main/java/com/youthexpedition/azit/modules/crew/adapter/out/persistence/CrewMemberPersistenceAdapter.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/adapter/out/persistence/CrewMemberPersistenceAdapter.java
@@ -116,4 +116,9 @@ public class CrewMemberPersistenceAdapter implements LoadCrewMemberPort, SaveCre
                 .map(crewMemberMapper::toJoinedCrewDto)
                 .toList();
     }
+
+    @Override
+    public void deleteByMemberId(Long memberId) {
+        crewMemberRepository.deleteByMemberId(memberId);
+    }
 }

--- a/src/main/java/com/youthexpedition/azit/modules/crew/adapter/out/persistence/CrewScheduleMemberPersistenceAdapter.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/adapter/out/persistence/CrewScheduleMemberPersistenceAdapter.java
@@ -1,0 +1,17 @@
+package com.youthexpedition.azit.modules.crew.adapter.out.persistence;
+
+import com.youthexpedition.azit.modules.crew.adapter.out.persistence.repository.CrewScheduleMemberRepository;
+import com.youthexpedition.azit.modules.crew.application.port.out.SaveCrewScheduleMemberPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CrewScheduleMemberPersistenceAdapter implements SaveCrewScheduleMemberPort {
+    private final CrewScheduleMemberRepository crewScheduleMemberRepository;
+
+    @Override
+    public void deleteByMemberId(Long memberId) {
+        crewScheduleMemberRepository.deleteByMemberId(memberId);
+    }
+}

--- a/src/main/java/com/youthexpedition/azit/modules/crew/adapter/out/persistence/repository/CrewMemberRepository.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/adapter/out/persistence/repository/CrewMemberRepository.java
@@ -3,6 +3,7 @@ package com.youthexpedition.azit.modules.crew.adapter.out.persistence.repository
 import com.youthexpedition.azit.modules.crew.adapter.out.persistence.entity.CrewMemberEntity;
 import com.youthexpedition.azit.modules.crew.domain.model.enums.CrewMemberStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -22,4 +23,8 @@ public interface CrewMemberRepository extends JpaRepository<CrewMemberEntity, Lo
 
     @Query("SELECT cm FROM CrewMemberEntity cm JOIN FETCH cm.crew WHERE cm.memberId = :memberId AND cm.status = :status")
     List<CrewMemberEntity> findAllJoinedCrewsByMemberId(@Param("memberId") Long memberId, @Param("status") CrewMemberStatus status);
+
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM CrewMemberEntity cm WHERE cm.memberId = :memberId")
+    void deleteByMemberId(@Param("memberId") Long memberId);
 }

--- a/src/main/java/com/youthexpedition/azit/modules/crew/adapter/out/persistence/repository/CrewScheduleMemberRepository.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/adapter/out/persistence/repository/CrewScheduleMemberRepository.java
@@ -1,0 +1,14 @@
+package com.youthexpedition.azit.modules.crew.adapter.out.persistence.repository;
+
+import com.youthexpedition.azit.modules.crew.adapter.out.persistence.entity.CrewScheduleMemberEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface CrewScheduleMemberRepository extends JpaRepository<CrewScheduleMemberEntity, Long> {
+
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM CrewScheduleMemberEntity csm WHERE csm.memberId = :memberId")
+    void deleteByMemberId(@Param("memberId") Long memberId);
+}

--- a/src/main/java/com/youthexpedition/azit/modules/crew/application/port/out/SaveCrewMemberPort.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/application/port/out/SaveCrewMemberPort.java
@@ -7,4 +7,5 @@ import java.util.List;
 public interface SaveCrewMemberPort {
     CrewMember save(CrewMember crewMember);
     void saveAll(List<CrewMember> crewMembers);
+    void deleteByMemberId(Long memberId);
 }

--- a/src/main/java/com/youthexpedition/azit/modules/crew/application/port/out/SaveCrewScheduleMemberPort.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/application/port/out/SaveCrewScheduleMemberPort.java
@@ -1,0 +1,5 @@
+package com.youthexpedition.azit.modules.crew.application.port.out;
+
+public interface SaveCrewScheduleMemberPort {
+    void deleteByMemberId(Long memberId);
+}

--- a/src/main/java/com/youthexpedition/azit/modules/crew/application/service/CrewScheduleService.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/application/service/CrewScheduleService.java
@@ -46,7 +46,7 @@ import java.util.stream.Collectors;
 @Service
 @RequiredArgsConstructor
 @Slf4j
-@Transactional
+@Transactional(readOnly = true)
 public class CrewScheduleService implements CrewScheduleUseCase {
     private final LoadCrewMemberPort loadCrewMemberPort;
     private final LoadCrewSchedulePort loadCrewSchedulePort;
@@ -62,6 +62,7 @@ public class CrewScheduleService implements CrewScheduleUseCase {
     private static final double CHECK_IN_AVAILABLE_DISTANCE_METERS = 1000.0;
 
     @Override
+    @Transactional
     public void createSchedule(CreateScheduleCommand command) {
         // 크루 정회원인지 확인
         CrewMember creator = getJoinedMember(command.crewId(), command.creatorId());
@@ -100,6 +101,7 @@ public class CrewScheduleService implements CrewScheduleUseCase {
     }
 
     @Override
+    @Transactional
     public void updateSchedule(UpdateScheduleCommand command) {
         CrewSchedule schedule = getSchedule(command.scheduleId());
 
@@ -140,6 +142,7 @@ public class CrewScheduleService implements CrewScheduleUseCase {
     }
 
     @Override
+    @Transactional
     public void cancelSchedule(CancelScheduleCommand command) {
         CrewSchedule schedule = getSchedule(command.scheduleId());
 
@@ -166,6 +169,7 @@ public class CrewScheduleService implements CrewScheduleUseCase {
     }
 
     @Override
+    @Transactional
     public void participateSchedule(CrewScheduleCommand command) {
         CrewSchedule schedule = getSchedule(command.scheduleId());
 
@@ -194,6 +198,7 @@ public class CrewScheduleService implements CrewScheduleUseCase {
     }
 
     @Override
+    @Transactional
     public void cancelParticipation(CrewScheduleCommand command) {
         CrewSchedule schedule = getSchedule(command.scheduleId());
 
@@ -221,7 +226,6 @@ public class CrewScheduleService implements CrewScheduleUseCase {
         saveCrewSchedulePort.save(schedule);
     }
 
-    @Transactional(readOnly = true)
     @Override
     public CrewScheduleDetailResponse getScheduleDetail(CrewScheduleCommand command) {
         ScheduleData data = getValidatedScheduleData(command);
@@ -231,7 +235,6 @@ public class CrewScheduleService implements CrewScheduleUseCase {
     }
 
     @Override
-    @Transactional(readOnly = true)
     public SliceResponse<ParticipantResponse> getScheduleParticipants(CrewScheduleCommand command, CursorPageQuery query) {
         ScheduleData data = getValidatedScheduleData(command);
 
@@ -266,7 +269,6 @@ public class CrewScheduleService implements CrewScheduleUseCase {
         return new ScheduleData(schedule, profileMap, crewMemberMap);
     }
 
-    @Transactional(readOnly = true)
     @Override
     public List<CrewScheduleListResponse> getSchedules(CrewScheduleQuery query) {
         // 정회원인지 확인
@@ -287,7 +289,6 @@ public class CrewScheduleService implements CrewScheduleUseCase {
         return crewScheduleResponseMapper.toScheduleListResponse(schedules, query.memberId(), activeMemberIdsMap);
     }
 
-    @Transactional(readOnly = true)
     @Override
     public List<CrewScheduleMonthlyListResponse> getMonthlySchedulesForCalendar(CrewScheduleMonthlyQuery query) {
         // 정회원인지 확인
@@ -298,7 +299,6 @@ public class CrewScheduleService implements CrewScheduleUseCase {
         return crewScheduleResponseMapper.toScheduleMonthlyListResponse(monthlyScheduleMap);
     }
 
-    @Transactional(readOnly = true)
     @Override
     public List<CrewScheduleListResponse> getMySchedules(Long memberId) {
         // 참여 중인 일정 조회
@@ -315,7 +315,6 @@ public class CrewScheduleService implements CrewScheduleUseCase {
         return crewScheduleResponseMapper.toScheduleListResponse(schedules, memberId, activeMemberIdsMap);
     }
 
-    @Transactional(readOnly = true)
     @Override
     public CheckInStatusResponse getCheckInStatus(Long memberId) {
         LocalDateTime now = LocalDateTime.now();
@@ -398,6 +397,7 @@ public class CrewScheduleService implements CrewScheduleUseCase {
     }
 
     @Override
+    @Transactional
     public void checkInSchedule(CheckInCommand command) {
         LocalDateTime now = LocalDateTime.now();
         CrewSchedule schedule = getSchedule(command.scheduleId());
@@ -441,7 +441,6 @@ public class CrewScheduleService implements CrewScheduleUseCase {
     }
 
     @Override
-    @Transactional(readOnly = true)
     public MyAttendanceLogResponse getMyAttendanceLogs(MyAttendanceMonthlyQuery query) {
         LocalDateTime now = LocalDateTime.now();
 
@@ -461,7 +460,6 @@ public class CrewScheduleService implements CrewScheduleUseCase {
         return crewScheduleResponseMapper.toMyAttendanceLogResponse(attendanceCount, totalPoints, attendanceLogs);
     }
 
-    @Transactional(readOnly = true)
     @Override
     public List<MyAttendanceMonthlyListResponse> getMyAttendancesForCalendar(MyAttendanceMonthlyQuery query) {
         LocalDateTime now = LocalDateTime.now();

--- a/src/main/java/com/youthexpedition/azit/modules/crew/application/service/CrewService.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/application/service/CrewService.java
@@ -39,6 +39,7 @@ import java.util.List;
 @Service
 @Slf4j
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class CrewService implements CrewUseCase {
     private final SaveCrewPort saveCrewPort;
     private final LoadCrewPort loadCrewPort;
@@ -53,6 +54,7 @@ public class CrewService implements CrewUseCase {
     private final ImageUpdateUtil imageUpdateUtil;
 
     @Override
+    @Transactional
     @Retryable(
             retryFor = {DataIntegrityViolationException.class}, // db 에러 시 재시도
             maxAttempts = 3,
@@ -144,7 +146,6 @@ public class CrewService implements CrewUseCase {
     }
 
     @Override
-    @Transactional(readOnly = true)
     public CrewInvitationResponse getCrewInfoByInvitationCode(String invitationCode) {
         Crew crew = loadCrewPort.findByInvitationCode(invitationCode)
                 .orElseThrow(() -> new BusinessException(CrewErrorCode.CREW_NOT_FOUND));
@@ -153,7 +154,6 @@ public class CrewService implements CrewUseCase {
     }
 
     @Override
-    @Transactional(readOnly = true)
     public CrewJoinStatusResponse getCrewJoinStatus(Long crewId, Long memberId) {
         Crew crew = loadCrewPort.findById(crewId)
                 .orElseThrow(() -> new BusinessException(CrewErrorCode.CREW_NOT_FOUND));
@@ -213,7 +213,6 @@ public class CrewService implements CrewUseCase {
     }
 
     @Override
-    @Transactional(readOnly = true)
     public List<JoinRequestMemberResponse> getJoinRequests(Long crewId, Long memberId) {
         validateLeader(crewId, memberId);
 
@@ -223,7 +222,6 @@ public class CrewService implements CrewUseCase {
     }
 
     @Override
-    @Transactional(readOnly = true)
     public CrewMemberListResponse getCrewMembers(Long crewId, Long memberId, CursorPageQuery query) {
         Crew crew = loadCrewPort.findById(crewId)
                 .orElseThrow(() -> new BusinessException(CrewErrorCode.CREW_NOT_FOUND));
@@ -309,6 +307,7 @@ public class CrewService implements CrewUseCase {
     }
 
     @Override
+    @Transactional
     @Retryable(
             retryFor = {DataIntegrityViolationException.class},
             maxAttempts = 3,
@@ -346,7 +345,6 @@ public class CrewService implements CrewUseCase {
     }
 
     @Override
-    @Transactional(readOnly = true)
     public CrewInfoResponse getCrewInfo(Long crewId, Long memberId) {
         Crew crew = loadCrewPort.findById(crewId)
                 .orElseThrow(() -> new BusinessException(CrewErrorCode.CREW_NOT_FOUND));
@@ -401,7 +399,6 @@ public class CrewService implements CrewUseCase {
     }
 
     @Override
-    @Transactional(readOnly = true)
     public List<JoinedCrewResponse> getJoinedCrews(Long memberId) {
         List<JoinedCrewDto> joinedCrews = loadCrewMemberPort.findJoinedCrewsByMemberId(memberId);
 

--- a/src/main/java/com/youthexpedition/azit/modules/crew/application/service/CrewService.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/application/service/CrewService.java
@@ -39,7 +39,6 @@ import java.util.List;
 @Service
 @Slf4j
 @RequiredArgsConstructor
-@Transactional
 public class CrewService implements CrewUseCase {
     private final SaveCrewPort saveCrewPort;
     private final LoadCrewPort loadCrewPort;
@@ -95,6 +94,7 @@ public class CrewService implements CrewUseCase {
     }
 
     @Override
+    @Transactional
     public void joinCrew(JoinCrewCommand command) {
         Crew crew = loadCrewPort.findByInvitationCode(command.invitationCode())
                 .orElseThrow(() -> new BusinessException(CrewErrorCode.CREW_NOT_FOUND));
@@ -328,6 +328,7 @@ public class CrewService implements CrewUseCase {
     }
 
     @Override
+    @Transactional
     public void updateCrewProfile(Long crewId, Long memberId, UpdateCrewProfileCommand command) {
         // 리더 권한 검증
         validateLeader(crewId, memberId);

--- a/src/main/java/com/youthexpedition/azit/modules/member/adapter/out/persistence/DeliveryAddressPersistenceAdapter.java
+++ b/src/main/java/com/youthexpedition/azit/modules/member/adapter/out/persistence/DeliveryAddressPersistenceAdapter.java
@@ -47,6 +47,11 @@ public class DeliveryAddressPersistenceAdapter implements LoadDeliveryAddressPor
     }
 
     @Override
+    public void deleteByMemberId(Long memberId) {
+        deliveryAddressRepository.deleteByMemberId(memberId);
+    }
+
+    @Override
     public List<DeliveryAddress> findAllByMemberIdOrderByDefaultDescCreatedAtDesc(Long memberId) {
         return deliveryAddressRepository.findAllByMemberIdOrderByDefaultDescCreatedAtDesc(memberId)
                 .stream()

--- a/src/main/java/com/youthexpedition/azit/modules/member/adapter/out/persistence/MemberPersistenceAdapter.java
+++ b/src/main/java/com/youthexpedition/azit/modules/member/adapter/out/persistence/MemberPersistenceAdapter.java
@@ -43,6 +43,11 @@ public class MemberPersistenceAdapter implements LoadMemberPort, SaveMemberPort 
     }
 
     @Override
+    public void deleteById(Long memberId) {
+        memberRepository.deleteById(memberId);
+    }
+
+    @Override
     public Map<Long, MemberProfileDto> findAllByIds(List<Long> memberIds) {
         return memberRepository.findAllById(memberIds).stream()
                 .filter(entity -> entity.getStatus() != MemberStatus.WITHDRAWN)

--- a/src/main/java/com/youthexpedition/azit/modules/member/adapter/out/persistence/PointHistoryPersistenceAdapter.java
+++ b/src/main/java/com/youthexpedition/azit/modules/member/adapter/out/persistence/PointHistoryPersistenceAdapter.java
@@ -18,4 +18,9 @@ public class PointHistoryPersistenceAdapter implements SavePointHistoryPort {
     public void save(PointHistory pointHistory) {
         pointHistoryRepository.save(pointHistoryMapper.toEntity(pointHistory));
     }
+
+    @Override
+    public void deleteByMemberId(Long memberId) {
+        pointHistoryRepository.deleteByMemberId(memberId);
+    }
 }

--- a/src/main/java/com/youthexpedition/azit/modules/member/adapter/out/persistence/repository/DeliveryAddressRepository.java
+++ b/src/main/java/com/youthexpedition/azit/modules/member/adapter/out/persistence/repository/DeliveryAddressRepository.java
@@ -2,10 +2,17 @@ package com.youthexpedition.azit.modules.member.adapter.out.persistence.reposito
 
 import com.youthexpedition.azit.modules.member.adapter.out.persistence.entity.DeliveryAddressEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface DeliveryAddressRepository extends JpaRepository<DeliveryAddressEntity, Long>, DeliveryAddressRepositoryCustom {
     boolean existsByMemberId(Long memberId);
     Optional<DeliveryAddressEntity> findByMemberIdAndIsDefaultTrue(Long memberId);
+
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM DeliveryAddressEntity da WHERE da.member.id = :memberId")
+    void deleteByMemberId(@Param("memberId") Long memberId);
 }

--- a/src/main/java/com/youthexpedition/azit/modules/member/adapter/out/persistence/repository/PointHistoryRepository.java
+++ b/src/main/java/com/youthexpedition/azit/modules/member/adapter/out/persistence/repository/PointHistoryRepository.java
@@ -2,6 +2,13 @@ package com.youthexpedition.azit.modules.member.adapter.out.persistence.reposito
 
 import com.youthexpedition.azit.modules.member.adapter.out.persistence.entity.PointHistoryEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface PointHistoryRepository extends JpaRepository<PointHistoryEntity, Long> {
+
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM PointHistoryEntity ph WHERE ph.memberId = :memberId")
+    void deleteByMemberId(@Param("memberId") Long memberId);
 }

--- a/src/main/java/com/youthexpedition/azit/modules/member/application/port/out/SaveDeliveryAddressPort.java
+++ b/src/main/java/com/youthexpedition/azit/modules/member/application/port/out/SaveDeliveryAddressPort.java
@@ -5,4 +5,5 @@ import com.youthexpedition.azit.modules.member.domain.model.DeliveryAddress;
 public interface SaveDeliveryAddressPort {
     void save(DeliveryAddress deliveryAddress);
     void delete(DeliveryAddress deliveryAddress);
+    void deleteByMemberId(Long memberId);
 }

--- a/src/main/java/com/youthexpedition/azit/modules/member/application/port/out/SaveMemberPort.java
+++ b/src/main/java/com/youthexpedition/azit/modules/member/application/port/out/SaveMemberPort.java
@@ -4,4 +4,5 @@ import com.youthexpedition.azit.modules.member.domain.model.Member;
 
 public interface SaveMemberPort {
     Member save(Member member);
+    void deleteById(Long memberId);
 }

--- a/src/main/java/com/youthexpedition/azit/modules/member/application/port/out/SavePointHistoryPort.java
+++ b/src/main/java/com/youthexpedition/azit/modules/member/application/port/out/SavePointHistoryPort.java
@@ -4,4 +4,5 @@ import com.youthexpedition.azit.modules.member.domain.model.PointHistory;
 
 public interface SavePointHistoryPort {
     void save(PointHistory pointHistory);
+    void deleteByMemberId(Long memberId);
 }

--- a/src/main/java/com/youthexpedition/azit/modules/member/application/service/DeliveryAddressService.java
+++ b/src/main/java/com/youthexpedition/azit/modules/member/application/service/DeliveryAddressService.java
@@ -18,13 +18,14 @@ import java.util.List;
 
 @Service
 @RequiredArgsConstructor
-@Transactional
+@Transactional(readOnly = true)
 public class DeliveryAddressService implements DeliveryAddressUseCase {
     private final LoadDeliveryAddressPort loadDeliveryAddressPort;
     private final SaveDeliveryAddressPort saveDeliveryAddressPort;
     private final DeliveryAddressResponseMapper deliveryAddressResponseMapper;
 
     @Override
+    @Transactional
     public void registerDeliveryAddress(RegisterAddressCommand command) {
         // 주소가 이미 있는지 확인
         boolean hasExistingAddress = loadDeliveryAddressPort.existsByMemberId(command.memberId());
@@ -49,6 +50,7 @@ public class DeliveryAddressService implements DeliveryAddressUseCase {
     }
 
     @Override
+    @Transactional
     public void updateDeliveryAddress(UpdateAddressCommand command) {
         DeliveryAddress deliveryAddress = getAddressValidated(command.addressId(), command.memberId());
         deliveryAddress.update(command.recipientName(), command.phoneNumber(), command.zipcode(), command.baseAddress(), command.detailAddress());
@@ -63,6 +65,7 @@ public class DeliveryAddressService implements DeliveryAddressUseCase {
     }
 
     @Override
+    @Transactional
     public void deleteDeliveryAddress(Long memberId, Long addressId) {
         DeliveryAddress deliveryAddress = getAddressValidated(addressId, memberId);
 
@@ -72,6 +75,13 @@ public class DeliveryAddressService implements DeliveryAddressUseCase {
         }
 
         saveDeliveryAddressPort.delete(deliveryAddress);
+    }
+
+    @Override
+    public List<DeliveryAddressResponse> getDeliveryAddresses(Long memberId) {
+        List<DeliveryAddress> deliveryAddresses = loadDeliveryAddressPort.findAllByMemberIdOrderByDefaultDescCreatedAtDesc(memberId);
+
+        return deliveryAddressResponseMapper.toAddressResponseList(deliveryAddresses);
     }
 
     // 주소 조회 및 현재 로그인한 멤버의 소유인지 검증
@@ -93,13 +103,5 @@ public class DeliveryAddressService implements DeliveryAddressUseCase {
                     oldDefault.markAsNonDefault();
                     saveDeliveryAddressPort.save(oldDefault);
                 });
-    }
-
-    @Override
-    @Transactional(readOnly = true)
-    public List<DeliveryAddressResponse> getDeliveryAddresses(Long memberId) {
-        List<DeliveryAddress> deliveryAddresses = loadDeliveryAddressPort.findAllByMemberIdOrderByDefaultDescCreatedAtDesc(memberId);
-
-        return deliveryAddressResponseMapper.toAddressResponseList(deliveryAddresses);
     }
 }

--- a/src/main/java/com/youthexpedition/azit/modules/member/application/service/MemberService.java
+++ b/src/main/java/com/youthexpedition/azit/modules/member/application/service/MemberService.java
@@ -39,7 +39,7 @@ import java.util.stream.Collectors;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-@Transactional
+@Transactional(readOnly = true)
 public class MemberService implements MemberUseCase {
     private final LoadMemberPort loadMemberPort;
     private final SaveMemberPort saveMemberPort;
@@ -55,6 +55,7 @@ public class MemberService implements MemberUseCase {
     private static final String BLACKLIST_REASON_WITHDRAWN = "withdrawn";
 
     @Override
+    @Transactional
     public void agreeToTerms(Long memberId, AgreeToTermsCommand command) {
         command.validateRequired(); // 필수 약관 동의 여부 검증
 
@@ -121,14 +122,12 @@ public class MemberService implements MemberUseCase {
     }
 
     @Override
-    @Transactional(readOnly = true)
     public MyInfoResponse getMyInfo(Long memberId) {
         Member member = getMember(memberId);
         return memberResponseMapper.toMyInfoResponse(member);
     }
 
     @Override
-    @Transactional(readOnly = true)
     public List<MyCrewResponse> getMyCrews(Long memberId) {
         List<CrewMember> activeCrewMembers = loadCrewMemberPort.findAllActiveByMemberId(memberId);
 
@@ -144,12 +143,25 @@ public class MemberService implements MemberUseCase {
     }
 
     @Override
-    @Transactional(readOnly = true)
     public LinkedProviderResponse getLinkedProviders(Long memberId) {
         Member member = getMember(memberId);
         // 추후 계정 연동 기능 추가 시, 연동된 소셜 계정 목록을 함께 조회하여 반환
         List<SocialProvider> providers = List.of(member.getSocialProvider());
         return LinkedProviderResponse.of(providers);
+    }
+
+    @Override
+    @Transactional
+    public void updateMemberProfile(Long memberId, UpdateMemberProfileCommand command) {
+        Member member = getMember(memberId);
+
+        // 닉네임 업데이트
+        member.updateNickname(command.nickname());
+
+        // 이미지 업데이트
+        imageUpdateUtil.update(command.imageUrl(), member.getProfileImageUrl(), memberId, true, member::updateProfileImageUrl);
+
+        saveMemberPort.save(member);
     }
 
     private Member getMember(Long memberId) {
@@ -180,19 +192,6 @@ public class MemberService implements MemberUseCase {
         LocalDateTime now = LocalDateTime.now();
         crewMembers.forEach(cm -> cm.exit(now));
         saveCrewMemberPort.saveAll(crewMembers);
-    }
-
-    @Override
-    public void updateMemberProfile(Long memberId, UpdateMemberProfileCommand command) {
-        Member member = getMember(memberId);
-
-        // 닉네임 업데이트
-        member.updateNickname(command.nickname());
-
-        // 이미지 업데이트
-        imageUpdateUtil.update(command.imageUrl(), member.getProfileImageUrl(), memberId, true, member::updateProfileImageUrl);
-
-        saveMemberPort.save(member);
     }
 
     // 본인이 리더인 크루가 있으면 앱 탈퇴 불가

--- a/src/main/java/com/youthexpedition/azit/modules/store/adapter/out/persistence/CartPersistenceAdapter.java
+++ b/src/main/java/com/youthexpedition/azit/modules/store/adapter/out/persistence/CartPersistenceAdapter.java
@@ -3,6 +3,7 @@ package com.youthexpedition.azit.modules.store.adapter.out.persistence;
 import com.youthexpedition.azit.modules.store.adapter.out.persistence.entity.CartItemEntity;
 import com.youthexpedition.azit.modules.store.adapter.out.persistence.mapper.CartMapper;
 import com.youthexpedition.azit.modules.store.adapter.out.persistence.repository.CartItemRepository;
+import com.youthexpedition.azit.modules.store.application.port.out.SaveCartItemPort;
 import com.youthexpedition.azit.modules.store.application.port.out.LoadCartPort;
 import com.youthexpedition.azit.modules.store.application.port.out.SaveCartPort;
 import com.youthexpedition.azit.modules.store.application.port.out.query.CartItemQueryDto;
@@ -17,7 +18,7 @@ import java.util.Optional;
 
 @Component
 @RequiredArgsConstructor
-public class CartPersistenceAdapter implements LoadCartPort, SaveCartPort {
+public class CartPersistenceAdapter implements LoadCartPort, SaveCartPort, SaveCartItemPort {
     private final CartItemRepository cartItemRepository;
     private final CartMapper cartMapper;
 
@@ -57,6 +58,11 @@ public class CartPersistenceAdapter implements LoadCartPort, SaveCartPort {
     @Override
     public List<CartItemQueryDto> findCartDetailsByMemberId(Long memberId) {
         return cartItemRepository.findCartDetailsByMemberId(memberId);
+    }
+
+    @Override
+    public void deleteByMemberId(Long memberId) {
+        cartItemRepository.deleteByMemberId(memberId);
     }
 
     @Override

--- a/src/main/java/com/youthexpedition/azit/modules/store/adapter/out/persistence/repository/CartItemRepository.java
+++ b/src/main/java/com/youthexpedition/azit/modules/store/adapter/out/persistence/repository/CartItemRepository.java
@@ -24,5 +24,9 @@ public interface CartItemRepository extends JpaRepository<CartItemEntity, Long>,
     @Query("DELETE FROM CartItemEntity ci WHERE ci.memberId = :memberId AND ci.id IN :ids")
     void deleteAllByMemberIdAndIds(@Param("memberId") Long memberId, @Param("ids") List<Long> ids);
 
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM CartItemEntity ci WHERE ci.memberId = :memberId")
+    void deleteByMemberId(@Param("memberId") Long memberId);
+
     long countByMemberId(Long memberId);
 }

--- a/src/main/java/com/youthexpedition/azit/modules/store/application/port/out/SaveCartItemPort.java
+++ b/src/main/java/com/youthexpedition/azit/modules/store/application/port/out/SaveCartItemPort.java
@@ -1,0 +1,5 @@
+package com.youthexpedition.azit.modules.store.application.port.out;
+
+public interface SaveCartItemPort {
+    void deleteByMemberId(Long memberId);
+}

--- a/src/main/java/com/youthexpedition/azit/modules/store/application/service/CartService.java
+++ b/src/main/java/com/youthexpedition/azit/modules/store/application/service/CartService.java
@@ -25,7 +25,7 @@ import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
-@Transactional
+@Transactional(readOnly = true)
 public class CartService implements CartUseCase {
     private final LoadCartPort loadCartPort;
     private final SaveCartPort saveCartPort;
@@ -33,6 +33,7 @@ public class CartService implements CartUseCase {
     private final CartResponseMapper cartResponseMapper;
 
     @Override
+    @Transactional
     public void addOrUpdateCartItem(AddToCartCommand command) {
         // 장바구니에 이미 동일한 SKU가 있는지 조회
         Optional<CartItem> existingItem = loadCartPort.findByMemberIdAndSkuId(command.memberId(), command.productSkuId());
@@ -96,6 +97,7 @@ public class CartService implements CartUseCase {
     }
 
     @Override
+    @Transactional
     public void deleteCartItems(Long memberId, CartItemDeleteCommand command) {
         if (command.cartItemIds() == null || command.cartItemIds().isEmpty()) {
             return;
@@ -105,7 +107,6 @@ public class CartService implements CartUseCase {
     }
 
     @Override
-    @Transactional(readOnly = true)
     public CartItemCountResponse getCartItemCount(Long memberId) {
         long count = loadCartPort.countByMemberId(memberId);
 
@@ -113,7 +114,6 @@ public class CartService implements CartUseCase {
     }
 
     @Override
-    @Transactional(readOnly = true)
     public List<CartItemListResponse> getCarts(Long memberId) {
         List<CartItemQueryDto> cartItems = loadCartPort.findCartDetailsByMemberId(memberId);
 

--- a/src/main/java/com/youthexpedition/azit/modules/store/application/service/OrderService.java
+++ b/src/main/java/com/youthexpedition/azit/modules/store/application/service/OrderService.java
@@ -45,7 +45,7 @@ import java.util.List;
 @Service
 @Slf4j
 @RequiredArgsConstructor
-@Transactional
+@Transactional(readOnly = true)
 public class OrderService implements OrderUseCase {
     private final LoadMemberPort loadMemberPort;
     private final SaveMemberPort saveMemberPort;
@@ -61,7 +61,6 @@ public class OrderService implements OrderUseCase {
     private final DeliveryAddressResponseMapper deliveryAddressResponseMapper;
 
     @Override
-    @Transactional(readOnly = true)
     public OrderCheckoutResponse getCheckoutInfoFromCart(Long memberId, List<Long> cartItemIds, Long deliveryAddressId) {
         Member member = getMember(memberId);
 
@@ -78,7 +77,6 @@ public class OrderService implements OrderUseCase {
     }
 
     @Override
-    @Transactional(readOnly = true)
     public OrderCheckoutResponse getCheckoutInfoDirect(Long memberId, Long skuId, Integer quantity, Long deliveryAddressId) {
         Member member = getMember(memberId);
 
@@ -96,6 +94,7 @@ public class OrderService implements OrderUseCase {
     }
 
     @Override
+    @Transactional
     @Retryable(
             retryFor = {DataIntegrityViolationException.class}, // db 에러 시 재시도
             maxAttempts = 3,
@@ -208,7 +207,6 @@ public class OrderService implements OrderUseCase {
     }
 
     @Override
-    @Transactional(readOnly = true)
     public OrderDetailResponse getOrderDetail(Long memberId, String orderNumber) {
         Order order = loadOrderPort.findByOrderNumber(orderNumber)
                 .orElseThrow(() -> new BusinessException(StoreErrorCode.ORDER_NOT_FOUND));
@@ -222,7 +220,6 @@ public class OrderService implements OrderUseCase {
     }
 
     @Override
-    @Transactional(readOnly = true)
     public SliceResponse<OrderListResponse> getOrders(Long memberId, CursorPageQuery query) {
         SliceResponse<Order> orderSlice = loadOrderPort.findOrdersByMemberId(memberId, query);
 

--- a/src/main/java/com/youthexpedition/azit/modules/store/application/service/ProductService.java
+++ b/src/main/java/com/youthexpedition/azit/modules/store/application/service/ProductService.java
@@ -18,13 +18,12 @@ import java.util.List;
 
 @Service
 @RequiredArgsConstructor
-@Transactional
+@Transactional(readOnly = true)
 public class ProductService implements ProductUseCase {
     private final LoadProductPort loadProductPort;
     private final ProductResponseMapper productResponseMapper;
 
     @Override
-    @Transactional(readOnly = true)
     public SliceResponse<ProductListResponse> getProducts(CursorPageQuery query) {
         SliceResponse<Product> productSlice = loadProductPort.findProducts(query);
 
@@ -36,7 +35,6 @@ public class ProductService implements ProductUseCase {
     }
 
     @Override
-    @Transactional(readOnly = true)
     public ProductDetailResponse getProduct(Long productId) {
         Product product = loadProductPort.findById(productId)
                 .orElseThrow(() -> new BusinessException(StoreErrorCode.PRODUCT_NOT_FOUND));

--- a/src/main/java/com/youthexpedition/azit/modules/test/adapter/in/web/TestMemberController.java
+++ b/src/main/java/com/youthexpedition/azit/modules/test/adapter/in/web/TestMemberController.java
@@ -7,10 +7,12 @@ import com.youthexpedition.azit.infrastructure.common.response.code.CommonSucces
 import com.youthexpedition.azit.modules.test.adapter.in.web.docs.TestMemberControllerDocs;
 import com.youthexpedition.azit.modules.test.application.port.in.TestMemberUseCase;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Profile({"local", "dev"})
 @RestController
 @RequestMapping("/api/v1/test/members")
 @RequiredArgsConstructor

--- a/src/main/java/com/youthexpedition/azit/modules/test/adapter/in/web/TestMemberController.java
+++ b/src/main/java/com/youthexpedition/azit/modules/test/adapter/in/web/TestMemberController.java
@@ -1,0 +1,26 @@
+package com.youthexpedition.azit.modules.test.adapter.in.web;
+
+import com.youthexpedition.azit.infrastructure.common.annotation.CurrentAccessToken;
+import com.youthexpedition.azit.infrastructure.common.annotation.CurrentMemberId;
+import com.youthexpedition.azit.infrastructure.common.response.CommonResponse;
+import com.youthexpedition.azit.infrastructure.common.response.code.CommonSuccessCode;
+import com.youthexpedition.azit.modules.test.adapter.in.web.docs.TestMemberControllerDocs;
+import com.youthexpedition.azit.modules.test.application.port.in.TestMemberUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/test/members")
+@RequiredArgsConstructor
+public class TestMemberController implements TestMemberControllerDocs {
+    private final TestMemberUseCase testMemberUseCase;
+
+    @PostMapping("/me/withdraw-immediately")
+    public CommonResponse<Void> forceWithdraw(@CurrentMemberId Long memberId, @CurrentAccessToken String accessToken) {
+        testMemberUseCase.forceWithdraw(memberId, accessToken);
+
+        return CommonResponse.of(CommonSuccessCode.SUCCESS);
+    }
+}

--- a/src/main/java/com/youthexpedition/azit/modules/test/adapter/in/web/docs/TestMemberControllerDocs.java
+++ b/src/main/java/com/youthexpedition/azit/modules/test/adapter/in/web/docs/TestMemberControllerDocs.java
@@ -1,0 +1,27 @@
+package com.youthexpedition.azit.modules.test.adapter.in.web.docs;
+
+import com.youthexpedition.azit.infrastructure.common.annotation.CurrentAccessToken;
+import com.youthexpedition.azit.infrastructure.common.annotation.CurrentMemberId;
+import com.youthexpedition.azit.infrastructure.common.response.CommonResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "[TEST]", description = "테스트용 API (운영 환경에서 사용 금지)")
+public interface TestMemberControllerDocs {
+
+    @Operation(
+            summary = "사용자 즉시 탈퇴",
+            description = """
+                    사용자 탈퇴 및 신규 가입 플로우 테스트를 위한 API입니다. <br>
+                    실제 탈퇴와 달리 사용자 관련 데이터를 DB에서 즉시 삭제합니다. <br><br>
+
+                    **[참고 사항]** <br>
+                    * 주문 관련 데이터는 운영과 동일하게 삭제하지 않습니다. (스냅샷 저장 용도) <br><br>
+                    """
+    )
+    CommonResponse<Void> forceWithdraw(
+            @Parameter(hidden = true) @CurrentMemberId Long memberId,
+            @Parameter(hidden = true) @CurrentAccessToken String accessToken
+    );
+}

--- a/src/main/java/com/youthexpedition/azit/modules/test/application/port/in/TestMemberUseCase.java
+++ b/src/main/java/com/youthexpedition/azit/modules/test/application/port/in/TestMemberUseCase.java
@@ -1,0 +1,5 @@
+package com.youthexpedition.azit.modules.test.application.port.in;
+
+public interface TestMemberUseCase {
+    void forceWithdraw(Long memberId, String accessToken);
+}

--- a/src/main/java/com/youthexpedition/azit/modules/test/application/service/TestMemberService.java
+++ b/src/main/java/com/youthexpedition/azit/modules/test/application/service/TestMemberService.java
@@ -49,6 +49,7 @@ public class TestMemberService implements TestMemberUseCase {
     @Transactional
     public void forceWithdraw(Long memberId, String accessToken) {
         log.warn("[TEST] memberId: {} 강제 탈퇴 처리를 시작합니다.", memberId);
+        Member member = getMember(memberId);
 
         // 탈퇴 가능한지 확인
         validateWithdrawal(memberId);
@@ -72,7 +73,6 @@ public class TestMemberService implements TestMemberUseCase {
         saveDeliveryAddressPort.deleteByMemberId(memberId);
 
         // 소셜 연동 해제
-        Member member = getMember(memberId);
         socialAuthPort.revoke(SocialRevokeCommand.from(member));
 
         // member 완전 삭제

--- a/src/main/java/com/youthexpedition/azit/modules/test/application/service/TestMemberService.java
+++ b/src/main/java/com/youthexpedition/azit/modules/test/application/service/TestMemberService.java
@@ -28,6 +28,7 @@ import java.util.List;
 @Slf4j
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class TestMemberService implements TestMemberUseCase {
 
     private static final String BLACKLIST_REASON_TEST_WITHDRAWN = "test-force-withdrawn";

--- a/src/main/java/com/youthexpedition/azit/modules/test/application/service/TestMemberService.java
+++ b/src/main/java/com/youthexpedition/azit/modules/test/application/service/TestMemberService.java
@@ -1,0 +1,127 @@
+package com.youthexpedition.azit.modules.test.application.service;
+
+import com.youthexpedition.azit.infrastructure.exception.BusinessException;
+import com.youthexpedition.azit.modules.auth.application.port.in.command.SocialRevokeCommand;
+import com.youthexpedition.azit.modules.auth.application.port.out.SocialAuthPort;
+import com.youthexpedition.azit.modules.auth.application.port.out.TokenPort;
+import com.youthexpedition.azit.modules.crew.application.port.out.*;
+import com.youthexpedition.azit.modules.crew.domain.model.Crew;
+import com.youthexpedition.azit.modules.crew.domain.model.CrewMember;
+import com.youthexpedition.azit.modules.crew.domain.model.enums.CrewErrorCode;
+import com.youthexpedition.azit.modules.crew.domain.model.enums.CrewMemberRole;
+import com.youthexpedition.azit.modules.crew.domain.model.enums.CrewMemberStatus;
+import com.youthexpedition.azit.modules.member.application.port.out.LoadMemberPort;
+import com.youthexpedition.azit.modules.member.application.port.out.SaveDeliveryAddressPort;
+import com.youthexpedition.azit.modules.member.application.port.out.SaveMemberPort;
+import com.youthexpedition.azit.modules.member.application.port.out.SavePointHistoryPort;
+import com.youthexpedition.azit.modules.member.domain.model.Member;
+import com.youthexpedition.azit.modules.member.domain.model.enums.MemberErrorCode;
+import com.youthexpedition.azit.modules.store.application.port.out.SaveCartItemPort;
+import com.youthexpedition.azit.modules.test.application.port.in.TestMemberUseCase;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class TestMemberService implements TestMemberUseCase {
+
+    private static final String BLACKLIST_REASON_TEST_WITHDRAWN = "test-force-withdrawn";
+
+    private final LoadMemberPort loadMemberPort;
+    private final SocialAuthPort socialAuthPort;
+    private final LoadCrewMemberPort loadCrewMemberPort;
+    private final LoadCrewPort loadCrewPort;
+    private final SaveCrewPort saveCrewPort;
+    private final SaveCrewScheduleMemberPort saveCrewScheduleMemberPort;
+    private final SaveCrewMemberPort saveCrewMemberPort;
+    private final SavePointHistoryPort savePointHistoryPort;
+    private final SaveCartItemPort saveCartItemPort;
+    private final SaveDeliveryAddressPort saveDeliveryAddressPort;
+    private final SaveMemberPort saveMemberPort;
+    private final TokenPort tokenPort;
+
+    @Override
+    @Transactional
+    public void forceWithdraw(Long memberId, String accessToken) {
+        log.warn("[TEST] memberId: {} 강제 탈퇴 처리를 시작합니다.", memberId);
+
+        // 탈퇴 가능한지 확인
+        validateWithdrawal(memberId);
+
+        // JOINED 상태인 크루의 인원수 차감
+        decreaseJoinedCrewMemberCounts(memberId);
+
+        // crew_schedule_member 완전 삭제
+        saveCrewScheduleMemberPort.deleteByMemberId(memberId);
+
+        // crew_member 완전 삭제
+        saveCrewMemberPort.deleteByMemberId(memberId);
+
+        // point_history 완전 삭제
+        savePointHistoryPort.deleteByMemberId(memberId);
+
+        // cart_item 완전 삭제
+        saveCartItemPort.deleteByMemberId(memberId);
+
+        // delivery_address 완전 삭제
+        saveDeliveryAddressPort.deleteByMemberId(memberId);
+
+        // 소셜 연동 해제
+        Member member = getMember(memberId);
+        socialAuthPort.revoke(SocialRevokeCommand.from(member));
+
+        // member 완전 삭제
+        saveMemberPort.deleteById(memberId);
+
+        // 토큰 처리
+        tokenPort.deleteByMemberId(memberId);
+        tokenPort.addToBlacklist(accessToken, BLACKLIST_REASON_TEST_WITHDRAWN);
+
+        log.warn("[TEST] memberId: {} 강제 탈퇴 처리가 완료되었습니다.", memberId);
+    }
+
+    private void decreaseJoinedCrewMemberCounts(Long memberId) {
+        List<CrewMember> crewMembers = loadCrewMemberPort.findAllByMemberId(memberId);
+        if (crewMembers.isEmpty()) return;
+
+        List<Long> joinedCrewIds = crewMembers.stream()
+                .filter(cm -> cm.getStatus() == CrewMemberStatus.JOINED)
+                .map(CrewMember::getCrewId)
+                .toList();
+
+        if (!joinedCrewIds.isEmpty()) {
+            log.info("[TEST] memberId: {}, crewIds: {} 탈퇴로 인해 인원수가 차감됩니다.", memberId, joinedCrewIds);
+            List<Crew> joinedCrews = loadCrewPort.findAllByIds(joinedCrewIds);
+            joinedCrews.forEach(Crew::decreaseMemberCount);
+            saveCrewPort.saveAll(joinedCrews);
+        }
+    }
+
+    private Member getMember(Long memberId) {
+        return loadMemberPort.findById(memberId)
+                .orElseThrow(() -> new BusinessException(MemberErrorCode.MEMBER_NOT_FOUND));
+    }
+
+    // 본인이 리더인 크루가 있으면 앱 탈퇴 불가
+    private void validateWithdrawal(Long memberId) {
+        // 사용자가 JOINED 상태이면서 리더인 크루 조회
+        List<CrewMember> crewMembersAsLeader = loadCrewMemberPort.findAllActiveByMemberId(memberId).stream()
+                .filter(cm -> cm.getStatus() == CrewMemberStatus.JOINED)
+                .filter(cm -> cm.getRole() == CrewMemberRole.LEADER)
+                .toList();
+
+        if (crewMembersAsLeader.isEmpty()) return;
+
+        List<Long> crewIds = crewMembersAsLeader.stream()
+                .map(CrewMember::getCrewId)
+                .toList();
+
+        log.warn("[TEST] memberId: {}, 리더로서 가입되어 있는 크루(crewIds: {})가 있어 앱 탈퇴가 불가능합니다.", memberId, crewIds);
+        throw new BusinessException(CrewErrorCode.CANNOT_SERVICE_WITHDRAW_AS_LEADER);
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
- #이슈번호 (예: #1)

## ✨ 작업 내용
> 이번 PR에서 변경된 핵심 내용을 요약해주세요.

- 프론트엔드 테스트용 즉시 탈퇴 API 구현
-

## 🧱 아키텍처 변경 요약
> 이번 작업으로 인해 변경된 주요 흐름을 적어주세요. (없으면 생략 가능)

- 예: 신규 UseCase 추가 및 외부 API 연동 어댑터 구현

## 📸 스크린샷 (선택 사항)
> API 테스트 결과 등을 첨부해주세요.

## ⚠️ 주의 사항 (선택)
- [ ] DB 스키마 변경이 있나요?
- [ ] API 명세(Swagger)가 업데이트 되었나요?
- [ ] 새로운 환경 변수(.env)가 추가 되었나요?

## ✅ 셀프 체크리스트
- [ ] 브랜치 전략(develop)에 맞게 올렸나요?
- [ ] 커밋 컨벤션을 준수했나요?
- [ ] 불필요한 주석이나 print문은 제거했나요?
- [ ] 로컬에서 테스트는 성공했나요?