### PR TITLE
[FEAT] 크루 일정 목록 조회 시 필터링에 시작일자, 종료일자 추가

### DIFF
--- a/src/main/java/com/youthexpedition/azit/infrastructure/common/util/image/ImageUrlFormatUtil.java
+++ b/src/main/java/com/youthexpedition/azit/infrastructure/common/util/image/ImageUrlFormatUtil.java
@@ -30,7 +30,7 @@ public class ImageUrlFormatUtil {
 
     /**
      * 이미지 경로에서 S3 Key 추출
-     * CloudFront URL: https://azitcrew.com/profile/123/2026-04-07_550e8400.jpg → profile/123/2026-04-07_550e8400.jpg
+     * CloudFront URL: https://images.azitcrew.com/profile/123/2026-04-07_550e8400.jpg → profile/123/2026-04-07_550e8400.jpg
      * 상대 경로:      /profile/123/2026-04-07_550e8400.jpg                     → profile/123/2026-04-07_550e8400.jpg
      */
     public String extractS3Key(String imageUrl) {

--- a/src/main/java/com/youthexpedition/azit/modules/crew/adapter/in/web/CrewScheduleController.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/adapter/in/web/CrewScheduleController.java
@@ -92,9 +92,14 @@ public class CrewScheduleController implements CrewScheduleControllerDocs {
 
     @GetMapping
     public CommonResponse<List<CrewScheduleListResponse>> getCrewSchedules(
-            @PathVariable Long crewId, @RequestParam(required = false) LocalDate date,
-            @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM") YearMonth yearMonth, @RequestParam(required = false) RunType runType, @CurrentMemberId Long memberId) {
-        CrewScheduleQuery query = CrewScheduleQuery.of(crewId, date, yearMonth, runType, memberId);
+            @PathVariable Long crewId,
+            @RequestParam(required = false) LocalDate date,
+            @RequestParam(required = false) LocalDate startDate,
+            @RequestParam(required = false) LocalDate endDate,
+            @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM") YearMonth yearMonth,
+            @RequestParam(required = false) RunType runType,
+            @CurrentMemberId Long memberId) {
+        CrewScheduleQuery query = CrewScheduleQuery.of(crewId, date, startDate, endDate, yearMonth, runType, memberId);
         List<CrewScheduleListResponse> response = crewScheduleUseCase.getSchedules(query);
 
         return CommonResponse.of(CommonSuccessCode.SUCCESS, response);

--- a/src/main/java/com/youthexpedition/azit/modules/crew/adapter/in/web/CrewScheduleController.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/adapter/in/web/CrewScheduleController.java
@@ -94,8 +94,8 @@ public class CrewScheduleController implements CrewScheduleControllerDocs {
     public CommonResponse<List<CrewScheduleListResponse>> getCrewSchedules(
             @PathVariable Long crewId,
             @RequestParam(required = false) LocalDate date,
-            @RequestParam(required = false) LocalDate startDate,
-            @RequestParam(required = false) LocalDate endDate,
+            @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate startDate,
+            @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate endDate,
             @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM") YearMonth yearMonth,
             @RequestParam(required = false) RunType runType,
             @CurrentMemberId Long memberId) {

--- a/src/main/java/com/youthexpedition/azit/modules/crew/adapter/in/web/docs/CrewScheduleControllerDocs.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/adapter/in/web/docs/CrewScheduleControllerDocs.java
@@ -181,12 +181,16 @@ public interface CrewScheduleControllerDocs {
             summary = "크루 일정 목록 조회",
             description = """
             특정 크루의 일정 목록을 날짜와 러닝 타입별로 필터링하여 조회합니다. <br>
-            
+
             **[쿼리 파라미터]** <br>
-            * date (선택): 특정 날짜(yyyy-MM-dd)의 일정만 조회하고 싶을 때 사용합니다. 미입력 시 전체 기간을 조회합니다.
-            * runType (선택): REGULAR 또는 LIGHTNING으로 필터링합니다. 미입력 시 모든 타입을 조회합니다.
-            * yearMonth (선택): 조회할 연월(yyyy-MM)입니다. 미입력 시 현재 시간 기준의 월을 기준으로 조회합니다. <br><br>
-            
+            * date (선택): 특정 날짜(yyyy-MM-dd)의 일정만 조회합니다. 다른 파라미터보다 우선 적용됩니다.
+            * startDate / endDate (선택): 조회할 날짜 범위(yyyy-MM-dd)입니다. 두 값이 모두 있어야 동작하며, 주 단위 조회에 활용합니다.
+            * yearMonth (선택): 조회할 연월(yyyy-MM)입니다. 미입력 시 현재 월을 기준으로 조회합니다.
+            * runType (선택): REGULAR 또는 LIGHTNING으로 필터링합니다. 미입력 시 모든 타입을 조회합니다. <br><br>
+
+            **[파라미터 우선순위]** <br>
+            date > startDate·endDate > yearMonth > 현재 월 <br><br>
+
             **[참고 사항]** <br>
             * 해당 크루의 정회원(JOINED)만 조회가 가능합니다. (NOT_A_CREW_MEMBER)
             * 결과 목록은 모임 시간(meetingAt)이 빠른 순서대로 정렬되어 반환됩니다.
@@ -199,6 +203,8 @@ public interface CrewScheduleControllerDocs {
     CommonResponse<List<CrewScheduleListResponse>> getCrewSchedules(
             @PathVariable Long crewId,
             @Parameter(description = "조회 날짜 (yyyy-MM-dd)") LocalDate date,
+            @Parameter(description = "조회 시작 날짜 (yyyy-MM-dd), endDate와 함께 사용") LocalDate startDate,
+            @Parameter(description = "조회 종료 날짜 (yyyy-MM-dd), startDate와 함께 사용") LocalDate endDate,
             @Parameter(description = "조회 연월 (yyyy-MM)") YearMonth yearMonth,
             @Parameter(description = "러닝 타입") RunType runType,
             @Parameter(hidden = true) @CurrentMemberId Long memberId);

--- a/src/main/java/com/youthexpedition/azit/modules/crew/adapter/in/web/docs/CrewScheduleControllerDocs.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/adapter/in/web/docs/CrewScheduleControllerDocs.java
@@ -197,7 +197,7 @@ public interface CrewScheduleControllerDocs {
             """
     )
     @ApiErrorCodeExamples({
-            "NOT_A_CREW_MEMBER",
+            "NOT_A_CREW_MEMBER", "INVALID_DATE_RANGE",
             "UNAUTHORIZED", "EXPIRED_TOKEN", "INVALID_TOKEN", "TOKEN_REUSE_DETECTED", "BLACKLISTED_TOKEN"
     })
     CommonResponse<List<CrewScheduleListResponse>> getCrewSchedules(

--- a/src/main/java/com/youthexpedition/azit/modules/crew/adapter/out/persistence/CrewSchedulePersistenceAdapter.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/adapter/out/persistence/CrewSchedulePersistenceAdapter.java
@@ -43,8 +43,8 @@ public class CrewSchedulePersistenceAdapter implements LoadCrewSchedulePort, Sav
     }
 
     @Override
-    public List<CrewSchedule> findAllByFilter(Long crewId, LocalDate date, YearMonth yearMonth, RunType runType) {
-        return crewScheduleRepository.findAllByFilter(crewId, date, yearMonth, runType).stream()
+    public List<CrewSchedule> findAllByFilter(Long crewId, LocalDate date, LocalDate startDate, LocalDate endDate, YearMonth yearMonth, RunType runType) {
+        return crewScheduleRepository.findAllByFilter(crewId, date, startDate, endDate, yearMonth, runType).stream()
                 .map(crewScheduleMapper::toDomain)
                 .toList();
     }

--- a/src/main/java/com/youthexpedition/azit/modules/crew/adapter/out/persistence/repository/CrewScheduleRepositoryCustom.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/adapter/out/persistence/repository/CrewScheduleRepositoryCustom.java
@@ -12,7 +12,7 @@ import java.util.Optional;
 import java.util.Set;
 
 public interface CrewScheduleRepositoryCustom {
-    List<CrewScheduleEntity> findAllByFilter(Long crewId, LocalDate date, YearMonth yearMonth, RunType runType);
+    List<CrewScheduleEntity> findAllByFilter(Long crewId, LocalDate date, LocalDate startDate, LocalDate endDate, YearMonth yearMonth, RunType runType);
     Map<LocalDate, Set<RunType>> findMonthlySchedulesForCalendar(Long crewId, YearMonth yearMonth);
     List<CrewScheduleEntity> findAllByMemberId(Long memberId);
     List<CrewScheduleEntity> findAllTodaySchedulesByMemberId(Long memberId, LocalDateTime now);

--- a/src/main/java/com/youthexpedition/azit/modules/crew/adapter/out/persistence/repository/CrewScheduleRepositoryImpl.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/adapter/out/persistence/repository/CrewScheduleRepositoryImpl.java
@@ -27,12 +27,12 @@ public class CrewScheduleRepositoryImpl implements CrewScheduleRepositoryCustom 
     private static final int ACTIVE_CHECK_IN_WINDOW_HOURS = 1;
 
     @Override
-    public List<CrewScheduleEntity> findAllByFilter(Long crewId, LocalDate date, YearMonth yearMonth, RunType runType) {
+    public List<CrewScheduleEntity> findAllByFilter(Long crewId, LocalDate date, LocalDate startDate, LocalDate endDate, YearMonth yearMonth, RunType runType) {
         return queryFactory.selectFrom(crewScheduleEntity)
                 .where(
                         crewScheduleEntity.crewId.eq(crewId),
-                        crewScheduleEntity.status.eq(ScheduleStatus.ACTIVE), // 삭제된 일정은 제외
-                        filterByDateOrMonth(date, yearMonth),
+                        crewScheduleEntity.status.eq(ScheduleStatus.ACTIVE),
+                        filterByDateRange(date, startDate, endDate, yearMonth),
                         eqRunType(runType)
                 )
                 .orderBy(crewScheduleEntity.meetingAt.asc())
@@ -225,14 +225,21 @@ public class CrewScheduleRepositoryImpl implements CrewScheduleRepositoryCustom 
         return crewId != null ? crewScheduleEntity.crewId.eq(crewId) : null;
     }
 
-    private BooleanExpression filterByDateOrMonth(LocalDate date, YearMonth yearMonth) {
-        // 특정 날짜가 있으면 해당 일자 조회
+    private BooleanExpression filterByDateRange(LocalDate date, LocalDate startDate, LocalDate endDate, YearMonth yearMonth) {
+        // 특정 날짜가 있으면 해당 일자 조회 (최우선)
         if (date != null) return eqDate(date);
+
+        // startDate/endDate 범위가 있으면 해당 범위 조회
+        if (startDate != null && endDate != null) {
+            return crewScheduleEntity.meetingAt.between(
+                    startDate.atStartOfDay(),
+                    endDate.atTime(LocalTime.MAX)
+            );
+        }
 
         // 월 정보가 없으면 현재 시간 기준 월로 설정
         YearMonth targetMonth = (yearMonth != null) ? yearMonth : YearMonth.now();
 
-        // 해당 월 전체 조회
         return crewScheduleEntity.meetingAt.between(
                 targetMonth.atDay(1).atStartOfDay(),
                 targetMonth.atEndOfMonth().atTime(LocalTime.MAX)

--- a/src/main/java/com/youthexpedition/azit/modules/crew/application/port/in/query/CrewScheduleQuery.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/application/port/in/query/CrewScheduleQuery.java
@@ -8,11 +8,13 @@ import java.time.YearMonth;
 public record CrewScheduleQuery(
         Long crewId,
         LocalDate date,
+        LocalDate startDate,
+        LocalDate endDate,
         YearMonth yearMonth,
         RunType runType,
         Long memberId
 ) {
-    public static CrewScheduleQuery of(Long crewId, LocalDate date, YearMonth yearMonth, RunType runType, Long memberId) {
-        return new CrewScheduleQuery(crewId, date, yearMonth, runType, memberId);
+    public static CrewScheduleQuery of(Long crewId, LocalDate date, LocalDate startDate, LocalDate endDate, YearMonth yearMonth, RunType runType, Long memberId) {
+        return new CrewScheduleQuery(crewId, date, startDate, endDate, yearMonth, runType, memberId);
     }
 }

--- a/src/main/java/com/youthexpedition/azit/modules/crew/application/port/out/LoadCrewSchedulePort.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/application/port/out/LoadCrewSchedulePort.java
@@ -13,7 +13,7 @@ import java.util.Set;
 
 public interface LoadCrewSchedulePort {
     Optional<CrewSchedule> findById(Long scheduleId);
-    List<CrewSchedule> findAllByFilter(Long crewId, LocalDate date, YearMonth yearMonth, RunType runType);
+    List<CrewSchedule> findAllByFilter(Long crewId, LocalDate date, LocalDate startDate, LocalDate endDate, YearMonth yearMonth, RunType runType);
     Map<LocalDate, Set<RunType>> findMonthlySchedulesForCalendar(Long crewId, YearMonth yearMonth);
     List<CrewSchedule> findAllByMemberId(Long memberId);
     List<CrewSchedule> findAllTodaySchedulesByMemberId(Long memberId, LocalDateTime now);

--- a/src/main/java/com/youthexpedition/azit/modules/crew/application/service/CrewScheduleService.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/application/service/CrewScheduleService.java
@@ -273,7 +273,7 @@ public class CrewScheduleService implements CrewScheduleUseCase {
         getJoinedMember(query.crewId(), query.memberId());
 
         // 필터링된 일정 목록 조회
-        List<CrewSchedule> schedules = loadCrewSchedulePort.findAllByFilter(query.crewId(), query.date(), query.yearMonth(), query.runType());
+        List<CrewSchedule> schedules = loadCrewSchedulePort.findAllByFilter(query.crewId(), query.date(), query.startDate(), query.endDate(), query.yearMonth(), query.runType());
 
         List<Long> allParticipantIds = schedules.stream()
                 .flatMap(s -> s.getParticipantIds().stream()).distinct().toList();

--- a/src/main/java/com/youthexpedition/azit/modules/crew/application/service/CrewScheduleService.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/application/service/CrewScheduleService.java
@@ -269,7 +269,7 @@ public class CrewScheduleService implements CrewScheduleUseCase {
     @Transactional(readOnly = true)
     @Override
     public List<CrewScheduleListResponse> getSchedules(CrewScheduleQuery query) {
-        // 정회원인지 확인
+        validateDateRange(query.startDate(), query.endDate());
         getJoinedMember(query.crewId(), query.memberId());
 
         // 필터링된 일정 목록 조회
@@ -519,6 +519,16 @@ public class CrewScheduleService implements CrewScheduleUseCase {
         if (!schedule.getCreatorId().equals(memberId)) {
             log.warn("[CREW_SCHEDULE] memberId: {} 가 본인이 생성하지 않은 scheduleId: {} 에 대해 조작을 시도했습니다.", memberId, schedule.getId());
             throw new BusinessException(CommonErrorCode.FORBIDDEN_ERROR);
+        }
+    }
+
+    private void validateDateRange(LocalDate startDate, LocalDate endDate) {
+        // startDate 또는 endDate 둘 중 하나만 있을 경우
+        boolean onlyOnePresent = (startDate == null) != (endDate == null);
+        // startDate가 endDate보다 과거일 경우
+        boolean startAfterEnd = startDate != null && startDate.isAfter(endDate);
+        if (onlyOnePresent || startAfterEnd) {
+            throw new BusinessException(CrewErrorCode.INVALID_DATE_RANGE);
         }
     }
 

--- a/src/main/java/com/youthexpedition/azit/modules/crew/domain/model/enums/CrewErrorCode.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/domain/model/enums/CrewErrorCode.java
@@ -46,6 +46,7 @@ public enum CrewErrorCode implements BaseErrorCode {
     CANNOT_CANCEL_AFTER_CHECK_IN("CANNOT_CANCEL_AFTER_CHECK_IN", "이미 출석 완료된 일정은 취소가 불가능합니다.", HttpStatus.BAD_REQUEST),
     SCHEDULE_MODIFICATION_NOT_ALLOWED_TIME("SCHEDULE_MODIFICATION_NOT_ALLOWED_TIME", "출석이 가능한 일정은 수정 및 삭제가 불가능합니다.", HttpStatus.BAD_REQUEST),
     PARTICIPATION_AND_CANCEL_CLOSED("PARTICIPATION_AND_CANCEL_CLOSED", "출석 가능 시간이 지나 일정 신청 및 취소가 불가능합니다.", HttpStatus.BAD_REQUEST),
+    INVALID_DATE_RANGE("INVALID_DATE_RANGE", "startDate와 endDate는 둘 다 입력되어야 하며, startDate는 endDate보다 이전이어야 합니다.", HttpStatus.BAD_REQUEST),
     ;
 
     private final String code;


### PR DESCRIPTION
## 📌 관련 이슈
- #이슈번호 (예: #1)

## ✨ 작업 내용
> 이번 PR에서 변경된 핵심 내용을 요약해주세요.

- 크루 일정 목록 조회 시 필터링에 시작일자, 종료일자 파라미터추가

## 🧱 아키텍처 변경 요약
> 이번 작업으로 인해 변경된 주요 흐름을 적어주세요. (없으면 생략 가능)

- 예: 신규 UseCase 추가 및 외부 API 연동 어댑터 구현

## 📸 스크린샷 (선택 사항)
> API 테스트 결과 등을 첨부해주세요.
<img width="731" height="443" alt="image" src="https://github.com/user-attachments/assets/84f1bdbc-2b3d-459e-9fbc-143242023299" />


## ⚠️ 주의 사항 (선택)
- [ ] DB 스키마 변경이 있나요?
- [x] API 명세(Swagger)가 업데이트 되었나요?
- [ ] 새로운 환경 변수(.env)가 추가 되었나요?

## ✅ 셀프 체크리스트
- [ ] 브랜치 전략(develop)에 맞게 올렸나요?
- [ ] 커밋 컨벤션을 준수했나요?
- [ ] 불필요한 주석이나 print문은 제거했나요?
- [ ] 로컬에서 테스트는 성공했나요?