### PR TITLE
[FEAT] 약관 버전 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,10 @@ dependencies {
     // Redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
+    // Cache (Caffeine)
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
+    implementation 'com.github.ben-manes.caffeine:caffeine'
+
     // QueryDSL
     implementation 'com.querydsl:querydsl-jpa:5.1.0:jakarta'
     annotationProcessor "com.querydsl:querydsl-apt:5.1.0:jakarta"

--- a/src/main/java/com/youthexpedition/azit/infrastructure/config/CacheConfig.java
+++ b/src/main/java/com/youthexpedition/azit/infrastructure/config/CacheConfig.java
@@ -1,0 +1,29 @@
+package com.youthexpedition.azit.infrastructure.config;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.caffeine.CaffeineCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Duration;
+
+@Configuration
+@EnableCaching
+public class CacheConfig {
+
+    public static final String LATEST_TERMS_VERSIONS = "latestTermsVersions";
+
+    private static final Duration TERMS_CACHE_TTL = Duration.ofMinutes(10); // TTL 10분
+
+    @Bean
+    public CacheManager cacheManager() {
+        CaffeineCacheManager cacheManager = new CaffeineCacheManager(LATEST_TERMS_VERSIONS);
+        cacheManager.setCaffeine(Caffeine.newBuilder()
+                .expireAfterWrite(TERMS_CACHE_TTL)
+                .maximumSize(100)
+                .recordStats()); // Actuator 캐시 메트릭(히트율 등) 수집용
+        return cacheManager;
+    }
+}

--- a/src/main/java/com/youthexpedition/azit/infrastructure/config/SecurityConfig.java
+++ b/src/main/java/com/youthexpedition/azit/infrastructure/config/SecurityConfig.java
@@ -47,17 +47,19 @@ public class SecurityConfig {
                         .requestMatchers("/actuator/health").permitAll()
                         .requestMatchers("/actuator/**").hasAuthority("ROLE_ADMIN")
                         .requestMatchers(securityProperties.getPermitAllPaths().toArray(String[]::new)).permitAll()
-                         // 공통 허용 경로 (로그인 등)
-                        .requestMatchers("/api/v1/auth/social-login/**",
+                         // 비로그인시에도 가능한 공통 허용 경로
+                        .requestMatchers(
+                                "/api/v1/auth/social-login/**",
                                 "/api/v1/auth/reissue",
                                 "/api/v1/auth/apple/notification"
                         ).permitAll()
 
-                        // 약관 동의는 약관 동의 대기 상태 회원만 가능
-                        .requestMatchers("/api/v1/members/terms").hasAuthority("STATUS_PENDING_TERMS")
-
-                        // 로그아웃은 약관 동의 전(PENDING_TERMS)·정상(ACTIVE) 회원 모두 가능
-                        .requestMatchers("/api/v1/auth/logout").hasAnyAuthority("STATUS_PENDING_TERMS", "STATUS_ACTIVE")
+                        // 약관 동의 전(PENDING_TERMS)·정상(ACTIVE) 회원 모두 가능
+                        .requestMatchers(
+                                "/api/v1/auth/logout",
+                                "/api/v1/members/terms"
+                        )
+                        .hasAnyAuthority("STATUS_PENDING_TERMS", "STATUS_ACTIVE")
 
                         // 나머지 모든 API: ACTIVE 상태(약관 동의 완료, 비탈퇴) 회원만 접근 가능
                         .anyRequest().hasAuthority("STATUS_ACTIVE")

--- a/src/main/java/com/youthexpedition/azit/modules/auth/adapter/in/web/docs/AuthControllerDocs.java
+++ b/src/main/java/com/youthexpedition/azit/modules/auth/adapter/in/web/docs/AuthControllerDocs.java
@@ -26,7 +26,7 @@ public interface AuthControllerDocs {
     @Operation(
             summary = "소셜 로그인 (애플 제외)",
             description = """
-            카카오 등 소셜 플랫폼의 인가 코드 및 액세스 토큰을 통해 로그인을 진행하고 JWT 토큰과 회원의 현재 상태, 최근 가입한 크루 ID를 반환합니다. <br><br>
+            카카오 등 소셜 플랫폼의 인가 코드 및 액세스 토큰을 통해 로그인을 진행합니다. <br><br>
             
             **[참고 사항]** <br>
             * 보안을 위해 리프레시 토큰은 HttpOnly 쿠키에 저장되어 발급됩니다.

--- a/src/main/java/com/youthexpedition/azit/modules/auth/application/port/in/dto/SocialLoginResponse.java
+++ b/src/main/java/com/youthexpedition/azit/modules/auth/application/port/in/dto/SocialLoginResponse.java
@@ -10,11 +10,13 @@ public record SocialLoginResponse(
         @Schema(description = "액세스 토큰")
         String accessToken,
         @Schema(description = "액세스 토큰 만료 시간 (초)")
-        long accessTokenExpiresIn, // 액세스 토큰 만료 시간
+        long accessTokenExpiresIn,
         @Schema(description = "회원 상태")
         MemberStatus status,
         @Schema(description = "가입한 크루 ID (없을 경우 null)")
-        Long crewId
+        Long crewId,
+        @Schema(description = "필수 약관 재동의 필요 여부")
+        boolean needsTermsUpdate
 ) {
     public static SocialLoginResponse from(AuthResult authResult) {
         return SocialLoginResponse.builder()
@@ -22,6 +24,7 @@ public record SocialLoginResponse(
                 .accessTokenExpiresIn(authResult.authToken().accessTokenExpiresIn())
                 .status(authResult.status())
                 .crewId(authResult.crewId())
+                .needsTermsUpdate(authResult.needsTermsUpdate())
                 .build();
     }
 }

--- a/src/main/java/com/youthexpedition/azit/modules/auth/application/service/SocialLoginService.java
+++ b/src/main/java/com/youthexpedition/azit/modules/auth/application/service/SocialLoginService.java
@@ -13,10 +13,15 @@ import com.youthexpedition.azit.modules.auth.domain.model.SocialProfile;
 import com.youthexpedition.azit.modules.crew.application.port.out.LoadCrewMemberPort;
 import com.youthexpedition.azit.modules.crew.domain.model.CrewMember;
 import com.youthexpedition.azit.modules.member.application.port.out.LoadMemberPort;
+import com.youthexpedition.azit.modules.member.application.port.out.LoadTermsVersionPort;
 import com.youthexpedition.azit.modules.member.application.port.out.SaveMemberPort;
 import com.youthexpedition.azit.modules.member.domain.model.Member;
+import com.youthexpedition.azit.modules.member.domain.model.TermsVersion;
 import com.youthexpedition.azit.modules.member.domain.model.enums.MemberStatus;
 import com.youthexpedition.azit.modules.member.domain.model.provider.ProfileImageProvider;
+
+import java.util.List;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -32,6 +37,7 @@ public class SocialLoginService implements SocialLoginUseCase {
     private final SaveMemberPort saveMemberPort;
     private final TokenPort tokenPort;
     private final LoadCrewMemberPort loadCrewMemberPort;
+    private final LoadTermsVersionPort loadTermsVersionPort;
     private final JwtProvider jwtProvider;
     private final ProfileImageProvider profileImageProvider;
 
@@ -49,11 +55,13 @@ public class SocialLoginService implements SocialLoginUseCase {
         Member savedMember = saveMemberPort.save(member);
 
         Long crewId = null;
-        // ACTIVE 상태일 경우 가장 최근에 가입한 크루 조회
-        if (member.getStatus() == MemberStatus.ACTIVE) {
+        boolean needsTermsUpdate = false;
+        // ACTIVE 상태일 경우 가장 최근에 가입한 크루 조회 및 약관 버전 체크
+        if (savedMember.getStatus() == MemberStatus.ACTIVE) {
             crewId = loadCrewMemberPort.findRecentJoinedCrewMember(savedMember.getId())
                     .map(CrewMember::getCrewId)
                     .orElse(null);
+            needsTermsUpdate = hasRequiredTermsUpdate(savedMember.getId());
         }
 
         // 토큰 생성
@@ -66,7 +74,12 @@ public class SocialLoginService implements SocialLoginUseCase {
         // Redis에 Refresh Token 저장
         saveRefreshToken(savedMember.getId(), authToken.refreshToken());
 
-        return new AuthResult(authToken, savedMember.getStatus(), crewId);
+        return AuthResult.builder()
+                .authToken(authToken)
+                .status(savedMember.getStatus())
+                .crewId(crewId)
+                .needsTermsUpdate(needsTermsUpdate)
+                .build();
     }
 
     private Member upsertMember(SocialProfile profile) {
@@ -100,6 +113,14 @@ public class SocialLoginService implements SocialLoginUseCase {
         }
 
         return member;
+    }
+
+    private boolean hasRequiredTermsUpdate(Long memberId) {
+        List<TermsVersion> latestVersions = loadTermsVersionPort.findAllLatest();
+        Set<Long> consentedVersionIds = loadTermsVersionPort.findConsentedVersionIdsByMemberId(memberId);
+        return latestVersions.stream()
+                .filter(TermsVersion::isRequired)
+                .anyMatch(v -> !consentedVersionIds.contains(v.getId()));
     }
 
     private void saveRefreshToken(Long memberId, String refreshToken) {

--- a/src/main/java/com/youthexpedition/azit/modules/auth/application/service/TokenManagementService.java
+++ b/src/main/java/com/youthexpedition/azit/modules/auth/application/service/TokenManagementService.java
@@ -10,9 +10,14 @@ import com.youthexpedition.azit.modules.auth.domain.model.enums.AuthErrorCode;
 import com.youthexpedition.azit.modules.crew.application.port.out.LoadCrewMemberPort;
 import com.youthexpedition.azit.modules.crew.domain.model.CrewMember;
 import com.youthexpedition.azit.modules.member.application.port.out.LoadMemberPort;
+import com.youthexpedition.azit.modules.member.application.port.out.LoadTermsVersionPort;
 import com.youthexpedition.azit.modules.member.domain.model.Member;
+import com.youthexpedition.azit.modules.member.domain.model.TermsVersion;
 import com.youthexpedition.azit.modules.member.domain.model.enums.MemberErrorCode;
 import com.youthexpedition.azit.modules.member.domain.model.enums.MemberStatus;
+
+import java.util.List;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -27,6 +32,7 @@ public class TokenManagementService implements TokenUseCase {
     private final TokenPort tokenPort;
     private final TokenProviderPort tokenProviderPort;
     private final LoadCrewMemberPort loadCrewMemberPort;
+    private final LoadTermsVersionPort loadTermsVersionPort;
 
     private static final String BLACKLIST_REASON_LOGOUT = "logout";
     private static final long PREV_TOKEN_TTL_SECONDS = 5;
@@ -75,7 +81,12 @@ public class TokenManagementService implements TokenUseCase {
                     .accessTokenExpiresIn(tokenProviderPort.getAccessTokenExpirationSeconds())
                     .build();
 
-            return new AuthResult(token, member.getStatus(), resolveCrewId(member));
+            return AuthResult.builder()
+                    .authToken(token)
+                    .status(member.getStatus())
+                    .crewId(resolveCrewId(member))
+                    .needsTermsUpdate(hasRequiredTermsUpdate(member))
+                    .build();
         }
 
         // 정상 경로
@@ -85,7 +96,12 @@ public class TokenManagementService implements TokenUseCase {
                 .accessTokenExpiresIn(tokenProviderPort.getAccessTokenExpirationSeconds())
                 .build();
 
-        return new AuthResult(token, member.getStatus(), resolveCrewId(member));
+        return AuthResult.builder()
+                    .authToken(token)
+                    .status(member.getStatus())
+                    .crewId(resolveCrewId(member))
+                    .needsTermsUpdate(hasRequiredTermsUpdate(member))
+                    .build();
     }
 
     private Long resolveCrewId(Member member) {
@@ -93,6 +109,15 @@ public class TokenManagementService implements TokenUseCase {
         return loadCrewMemberPort.findRecentJoinedCrewMember(member.getId())
                 .map(CrewMember::getCrewId)
                 .orElse(null);
+    }
+
+    private boolean hasRequiredTermsUpdate(Member member) {
+        if (member.getStatus() != MemberStatus.ACTIVE) return false;
+        List<TermsVersion> latestVersions = loadTermsVersionPort.findAllLatest();
+        Set<Long> consentedVersionIds = loadTermsVersionPort.findConsentedVersionIdsByMemberId(member.getId());
+        return latestVersions.stream()
+                .filter(TermsVersion::isRequired)
+                .anyMatch(v -> !consentedVersionIds.contains(v.getId()));
     }
 
     @Override

--- a/src/main/java/com/youthexpedition/azit/modules/auth/domain/model/AuthResult.java
+++ b/src/main/java/com/youthexpedition/azit/modules/auth/domain/model/AuthResult.java
@@ -7,6 +7,7 @@ import lombok.Builder;
 public record AuthResult(
         AuthToken authToken,
         MemberStatus status,
-        Long crewId
+        Long crewId,
+        boolean needsTermsUpdate
 ) {
 }

--- a/src/main/java/com/youthexpedition/azit/modules/crew/adapter/in/web/docs/CrewControllerDocs.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/adapter/in/web/docs/CrewControllerDocs.java
@@ -69,11 +69,11 @@ public interface CrewControllerDocs {
             사용자가 가입 신청을 하기 전, 크루 정보를 미리 확인할 때 사용합니다. <br><br>
             
             **[제약 사항]** <br>
-            * 존재하지 않거나 잘못된 초대 코드일 경우 CREW_NOT_FOUND 오류가 발생합니다.
+            * 유효하지 않거나 만료된 초대 코드일 경우 INVALID_INVITATION_CODE 오류가 발생합니다.
             """
     )
     @ApiErrorCodeExamples({
-            "CREW_NOT_FOUND",
+            "INVALID_INVITATION_CODE",
             "UNAUTHORIZED", "EXPIRED_TOKEN", "INVALID_TOKEN", "TOKEN_REUSE_DETECTED", "BLACKLISTED_TOKEN"
     })
     CommonResponse<CrewInvitationResponse> getCrewByInvitation(@PathVariable String invitationCode);

--- a/src/main/java/com/youthexpedition/azit/modules/crew/application/service/CrewService.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/application/service/CrewService.java
@@ -148,7 +148,11 @@ public class CrewService implements CrewUseCase {
     @Override
     public CrewInvitationResponse getCrewInfoByInvitationCode(String invitationCode) {
         Crew crew = loadCrewPort.findByInvitationCode(invitationCode)
-                .orElseThrow(() -> new BusinessException(CrewErrorCode.CREW_NOT_FOUND));
+                .orElseThrow(() -> new BusinessException(CrewErrorCode.INVALID_INVITATION_CODE));
+
+        if (crew.isDissolved()) {
+            throw new BusinessException(CrewErrorCode.INVALID_INVITATION_CODE);
+        }
 
         return crewResponseMapper.toInvitationResponse(crew);
     }

--- a/src/main/java/com/youthexpedition/azit/modules/crew/domain/model/enums/CrewErrorCode.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/domain/model/enums/CrewErrorCode.java
@@ -10,7 +10,7 @@ import org.springframework.http.HttpStatus;
 public enum CrewErrorCode implements BaseErrorCode {
     // 크루 관련
     CREW_NOT_FOUND("CREW_NOT_FOUND", "존재하지 않는 크루입니다.", HttpStatus.NOT_FOUND),
-    EXPIRED_INVITATION_CODE("EXPIRED_INVITATION_CODE", "유효하지 않거나 이미 만료된 초대 코드입니다.", HttpStatus.BAD_REQUEST),
+    INVALID_INVITATION_CODE("INVALID_INVITATION_CODE", "유효하지 않거나 이미 만료된 초대 코드입니다.", HttpStatus.BAD_REQUEST),
     INVALID_CREW_CATEGORY("INVALID_CREW_CATEGORY", "유효하지 않은 크루 카테고리입니다.", HttpStatus.BAD_REQUEST),
     INVALID_REGION("INVALID_REGION", "유효하지 않은 활동 지역입니다.", HttpStatus.BAD_REQUEST),
     ALREADY_JOINED_CREW("ALREADY_JOINED_CREW", "이미 가입한 크루입니다.", HttpStatus.BAD_REQUEST),

--- a/src/main/java/com/youthexpedition/azit/modules/member/adapter/out/mapper/MemberTermsConsentHistoryMapper.java
+++ b/src/main/java/com/youthexpedition/azit/modules/member/adapter/out/mapper/MemberTermsConsentHistoryMapper.java
@@ -1,0 +1,18 @@
+package com.youthexpedition.azit.modules.member.adapter.out.mapper;
+
+import com.youthexpedition.azit.modules.member.adapter.out.persistence.entity.MemberTermsConsentHistoryEntity;
+import com.youthexpedition.azit.modules.member.domain.model.MemberTermsConsentHistory;
+import org.springframework.stereotype.Component;
+
+@Component
+public class MemberTermsConsentHistoryMapper {
+
+    public MemberTermsConsentHistoryEntity toEntity(MemberTermsConsentHistory domain) {
+        return MemberTermsConsentHistoryEntity.builder()
+                .memberId(domain.getMemberId())
+                .termsVersionId(domain.getTermsVersionId())
+                .isAgreed(domain.isAgreed())
+                .changedAt(domain.getChangedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/youthexpedition/azit/modules/member/adapter/out/mapper/MemberTermsConsentHistoryMapper.java
+++ b/src/main/java/com/youthexpedition/azit/modules/member/adapter/out/mapper/MemberTermsConsentHistoryMapper.java
@@ -12,7 +12,6 @@ public class MemberTermsConsentHistoryMapper {
                 .memberId(domain.getMemberId())
                 .termsVersionId(domain.getTermsVersionId())
                 .isAgreed(domain.isAgreed())
-                .changedAt(domain.getChangedAt())
                 .build();
     }
 }

--- a/src/main/java/com/youthexpedition/azit/modules/member/adapter/out/mapper/MemberTermsConsentMapper.java
+++ b/src/main/java/com/youthexpedition/azit/modules/member/adapter/out/mapper/MemberTermsConsentMapper.java
@@ -1,0 +1,28 @@
+package com.youthexpedition.azit.modules.member.adapter.out.mapper;
+
+import com.youthexpedition.azit.modules.member.adapter.out.persistence.entity.MemberTermsConsentEntity;
+import com.youthexpedition.azit.modules.member.domain.model.MemberTermsConsent;
+import org.springframework.stereotype.Component;
+
+@Component
+public class MemberTermsConsentMapper {
+
+    public MemberTermsConsent toDomain(MemberTermsConsentEntity entity) {
+        return MemberTermsConsent.builder()
+                .id(entity.getId())
+                .memberId(entity.getMemberId())
+                .termsVersionId(entity.getTermsVersionId())
+                .agreedAt(entity.getAgreedAt())
+                .createdAt(entity.getCreatedAt())
+                .updatedAt(entity.getUpdatedAt())
+                .build();
+    }
+
+    public MemberTermsConsentEntity toEntity(MemberTermsConsent domain) {
+        return MemberTermsConsentEntity.builder()
+                .memberId(domain.getMemberId())
+                .termsVersionId(domain.getTermsVersionId())
+                .agreedAt(domain.getAgreedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/youthexpedition/azit/modules/member/adapter/out/mapper/TermsVersionMapper.java
+++ b/src/main/java/com/youthexpedition/azit/modules/member/adapter/out/mapper/TermsVersionMapper.java
@@ -1,0 +1,21 @@
+package com.youthexpedition.azit.modules.member.adapter.out.mapper;
+
+import com.youthexpedition.azit.modules.member.adapter.out.persistence.entity.TermsVersionEntity;
+import com.youthexpedition.azit.modules.member.domain.model.TermsVersion;
+import org.springframework.stereotype.Component;
+
+@Component
+public class TermsVersionMapper {
+
+    public TermsVersion toDomain(TermsVersionEntity entity) {
+        return TermsVersion.builder()
+                .id(entity.getId())
+                .termsType(entity.getTermsType())
+                .version(entity.getVersion())
+                .isRequired(entity.isRequired())
+                .effectiveAt(entity.getEffectiveAt())
+                .createdAt(entity.getCreatedAt())
+                .updatedAt(entity.getUpdatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/youthexpedition/azit/modules/member/adapter/out/persistence/TermsPersistenceAdapter.java
+++ b/src/main/java/com/youthexpedition/azit/modules/member/adapter/out/persistence/TermsPersistenceAdapter.java
@@ -53,7 +53,7 @@ public class TermsPersistenceAdapter implements LoadTermsVersionPort, SaveMember
 
     @Override
     public void updateAgreedAt(Long memberId, Set<Long> versionIds, LocalDateTime agreedAt) {
-        memberTermsConsentRepository.updateAgreedAt(memberId, (Collection<Long>) versionIds, agreedAt);
+        memberTermsConsentRepository.updateAgreedAt(memberId, versionIds, agreedAt);
     }
 
     @Override

--- a/src/main/java/com/youthexpedition/azit/modules/member/adapter/out/persistence/TermsPersistenceAdapter.java
+++ b/src/main/java/com/youthexpedition/azit/modules/member/adapter/out/persistence/TermsPersistenceAdapter.java
@@ -8,10 +8,12 @@ import com.youthexpedition.azit.modules.member.adapter.out.persistence.repositor
 import com.youthexpedition.azit.modules.member.adapter.out.persistence.repository.TermsVersionRepository;
 import com.youthexpedition.azit.modules.member.application.port.out.LoadTermsVersionPort;
 import com.youthexpedition.azit.modules.member.application.port.out.SaveMemberTermsConsentPort;
+import com.youthexpedition.azit.infrastructure.config.CacheConfig;
 import com.youthexpedition.azit.modules.member.domain.model.MemberTermsConsent;
 import com.youthexpedition.azit.modules.member.domain.model.MemberTermsConsentHistory;
 import com.youthexpedition.azit.modules.member.domain.model.TermsVersion;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
@@ -30,7 +32,10 @@ public class TermsPersistenceAdapter implements LoadTermsVersionPort, SaveMember
     private final MemberTermsConsentMapper memberTermsConsentMapper;
     private final MemberTermsConsentHistoryMapper memberTermsConsentHistoryMapper;
 
+    // 약관 버전은 변경 빈도가 매우 낮으므로 TTL 기반 로컬 캐시 적용
+    // 추후 어드민에서 약관 변경하는 api 구현될 경우 @CacheEvict 적용 필요
     @Override
+    @Cacheable(value = CacheConfig.LATEST_TERMS_VERSIONS)
     public List<TermsVersion> findAllLatest() {
         return termsVersionRepository.findAllLatest().stream()
                 .map(termsVersionMapper::toDomain)

--- a/src/main/java/com/youthexpedition/azit/modules/member/adapter/out/persistence/TermsPersistenceAdapter.java
+++ b/src/main/java/com/youthexpedition/azit/modules/member/adapter/out/persistence/TermsPersistenceAdapter.java
@@ -1,0 +1,67 @@
+package com.youthexpedition.azit.modules.member.adapter.out.persistence;
+
+import com.youthexpedition.azit.modules.member.adapter.out.mapper.MemberTermsConsentHistoryMapper;
+import com.youthexpedition.azit.modules.member.adapter.out.mapper.MemberTermsConsentMapper;
+import com.youthexpedition.azit.modules.member.adapter.out.mapper.TermsVersionMapper;
+import com.youthexpedition.azit.modules.member.adapter.out.persistence.repository.MemberTermsConsentHistoryRepository;
+import com.youthexpedition.azit.modules.member.adapter.out.persistence.repository.MemberTermsConsentRepository;
+import com.youthexpedition.azit.modules.member.adapter.out.persistence.repository.TermsVersionRepository;
+import com.youthexpedition.azit.modules.member.application.port.out.LoadTermsVersionPort;
+import com.youthexpedition.azit.modules.member.application.port.out.SaveMemberTermsConsentPort;
+import com.youthexpedition.azit.modules.member.domain.model.MemberTermsConsent;
+import com.youthexpedition.azit.modules.member.domain.model.MemberTermsConsentHistory;
+import com.youthexpedition.azit.modules.member.domain.model.TermsVersion;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+
+@Component
+@RequiredArgsConstructor
+public class TermsPersistenceAdapter implements LoadTermsVersionPort, SaveMemberTermsConsentPort {
+
+    private final TermsVersionRepository termsVersionRepository;
+    private final MemberTermsConsentRepository memberTermsConsentRepository;
+    private final MemberTermsConsentHistoryRepository memberTermsConsentHistoryRepository;
+    private final TermsVersionMapper termsVersionMapper;
+    private final MemberTermsConsentMapper memberTermsConsentMapper;
+    private final MemberTermsConsentHistoryMapper memberTermsConsentHistoryMapper;
+
+    @Override
+    public List<TermsVersion> findAllLatest() {
+        return termsVersionRepository.findAllLatest().stream()
+                .map(termsVersionMapper::toDomain)
+                .toList();
+    }
+
+    @Override
+    public Set<Long> findConsentedVersionIdsByMemberId(Long memberId) {
+        return memberTermsConsentRepository.findTermsVersionIdsByMemberId(memberId);
+    }
+
+    @Override
+    public void saveAll(List<MemberTermsConsent> consents) {
+        memberTermsConsentRepository.saveAll(
+                consents.stream()
+                        .map(memberTermsConsentMapper::toEntity)
+                        .toList()
+        );
+    }
+
+    @Override
+    public void updateAgreedAt(Long memberId, Set<Long> versionIds, LocalDateTime agreedAt) {
+        memberTermsConsentRepository.updateAgreedAt(memberId, (Collection<Long>) versionIds, agreedAt);
+    }
+
+    @Override
+    public void saveAllHistory(List<MemberTermsConsentHistory> histories) {
+        memberTermsConsentHistoryRepository.saveAll(
+                histories.stream()
+                        .map(memberTermsConsentHistoryMapper::toEntity)
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/com/youthexpedition/azit/modules/member/adapter/out/persistence/TermsPersistenceAdapter.java
+++ b/src/main/java/com/youthexpedition/azit/modules/member/adapter/out/persistence/TermsPersistenceAdapter.java
@@ -57,6 +57,11 @@ public class TermsPersistenceAdapter implements LoadTermsVersionPort, SaveMember
     }
 
     @Override
+    public void deleteByMemberIdAndVersionIds(Long memberId, Set<Long> versionIds) {
+        memberTermsConsentRepository.deleteByMemberIdAndTermsVersionIdIn(memberId, versionIds);
+    }
+
+    @Override
     public void saveAllHistory(List<MemberTermsConsentHistory> histories) {
         memberTermsConsentHistoryRepository.saveAll(
                 histories.stream()

--- a/src/main/java/com/youthexpedition/azit/modules/member/adapter/out/persistence/TermsPersistenceAdapter.java
+++ b/src/main/java/com/youthexpedition/azit/modules/member/adapter/out/persistence/TermsPersistenceAdapter.java
@@ -1,5 +1,6 @@
 package com.youthexpedition.azit.modules.member.adapter.out.persistence;
 
+import com.youthexpedition.azit.infrastructure.config.CacheConfig;
 import com.youthexpedition.azit.modules.member.adapter.out.mapper.MemberTermsConsentHistoryMapper;
 import com.youthexpedition.azit.modules.member.adapter.out.mapper.MemberTermsConsentMapper;
 import com.youthexpedition.azit.modules.member.adapter.out.mapper.TermsVersionMapper;
@@ -8,7 +9,6 @@ import com.youthexpedition.azit.modules.member.adapter.out.persistence.repositor
 import com.youthexpedition.azit.modules.member.adapter.out.persistence.repository.TermsVersionRepository;
 import com.youthexpedition.azit.modules.member.application.port.out.LoadTermsVersionPort;
 import com.youthexpedition.azit.modules.member.application.port.out.SaveMemberTermsConsentPort;
-import com.youthexpedition.azit.infrastructure.config.CacheConfig;
 import com.youthexpedition.azit.modules.member.domain.model.MemberTermsConsent;
 import com.youthexpedition.azit.modules.member.domain.model.MemberTermsConsentHistory;
 import com.youthexpedition.azit.modules.member.domain.model.TermsVersion;
@@ -17,7 +17,6 @@ import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
-import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 

--- a/src/main/java/com/youthexpedition/azit/modules/member/adapter/out/persistence/entity/MemberTermsConsentEntity.java
+++ b/src/main/java/com/youthexpedition/azit/modules/member/adapter/out/persistence/entity/MemberTermsConsentEntity.java
@@ -1,0 +1,32 @@
+package com.youthexpedition.azit.modules.member.adapter.out.persistence.entity;
+
+import com.youthexpedition.azit.infrastructure.common.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(
+        name = "member_terms_consent",
+        uniqueConstraints = @UniqueConstraint(name = "uq_member_terms_version", columnNames = {"member_id", "terms_version_id"})
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class MemberTermsConsentEntity extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "member_id", nullable = false)
+    private Long memberId;
+
+    @Column(name = "terms_version_id", nullable = false)
+    private Long termsVersionId;
+
+    @Column(name = "agreed_at", nullable = false)
+    private LocalDateTime agreedAt;
+}

--- a/src/main/java/com/youthexpedition/azit/modules/member/adapter/out/persistence/entity/MemberTermsConsentHistoryEntity.java
+++ b/src/main/java/com/youthexpedition/azit/modules/member/adapter/out/persistence/entity/MemberTermsConsentHistoryEntity.java
@@ -1,9 +1,8 @@
 package com.youthexpedition.azit.modules.member.adapter.out.persistence.entity;
 
+import com.youthexpedition.azit.infrastructure.common.entity.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.*;
-
-import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "member_terms_consent_history")
@@ -11,7 +10,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Builder
-public class MemberTermsConsentHistoryEntity {
+public class MemberTermsConsentHistoryEntity extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -25,7 +24,4 @@ public class MemberTermsConsentHistoryEntity {
 
     @Column(name = "is_agreed", nullable = false)
     private boolean isAgreed;
-
-    @Column(name = "changed_at", nullable = false)
-    private LocalDateTime changedAt;
 }

--- a/src/main/java/com/youthexpedition/azit/modules/member/adapter/out/persistence/entity/MemberTermsConsentHistoryEntity.java
+++ b/src/main/java/com/youthexpedition/azit/modules/member/adapter/out/persistence/entity/MemberTermsConsentHistoryEntity.java
@@ -1,0 +1,31 @@
+package com.youthexpedition.azit.modules.member.adapter.out.persistence.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "member_terms_consent_history")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class MemberTermsConsentHistoryEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "member_id", nullable = false)
+    private Long memberId;
+
+    @Column(name = "terms_version_id", nullable = false)
+    private Long termsVersionId;
+
+    @Column(name = "is_agreed", nullable = false)
+    private boolean isAgreed;
+
+    @Column(name = "changed_at", nullable = false)
+    private LocalDateTime changedAt;
+}

--- a/src/main/java/com/youthexpedition/azit/modules/member/adapter/out/persistence/entity/TermsVersionEntity.java
+++ b/src/main/java/com/youthexpedition/azit/modules/member/adapter/out/persistence/entity/TermsVersionEntity.java
@@ -1,0 +1,37 @@
+package com.youthexpedition.azit.modules.member.adapter.out.persistence.entity;
+
+import com.youthexpedition.azit.infrastructure.common.entity.BaseTimeEntity;
+import com.youthexpedition.azit.modules.member.domain.model.enums.TermsType;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(
+        name = "terms_version",
+        uniqueConstraints = @UniqueConstraint(name = "uq_terms_version", columnNames = {"terms_type", "version"})
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class TermsVersionEntity extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "terms_type", nullable = false, length = 30)
+    private TermsType termsType;
+
+    @Column(name = "version", nullable = false, length = 20)
+    private String version;
+
+    @Column(name = "is_required", nullable = false)
+    private boolean isRequired;
+
+    @Column(name = "effective_at", nullable = false)
+    private LocalDateTime effectiveAt;
+}

--- a/src/main/java/com/youthexpedition/azit/modules/member/adapter/out/persistence/repository/MemberTermsConsentHistoryRepository.java
+++ b/src/main/java/com/youthexpedition/azit/modules/member/adapter/out/persistence/repository/MemberTermsConsentHistoryRepository.java
@@ -1,0 +1,7 @@
+package com.youthexpedition.azit.modules.member.adapter.out.persistence.repository;
+
+import com.youthexpedition.azit.modules.member.adapter.out.persistence.entity.MemberTermsConsentHistoryEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberTermsConsentHistoryRepository extends JpaRepository<MemberTermsConsentHistoryEntity, Long> {
+}

--- a/src/main/java/com/youthexpedition/azit/modules/member/adapter/out/persistence/repository/MemberTermsConsentRepository.java
+++ b/src/main/java/com/youthexpedition/azit/modules/member/adapter/out/persistence/repository/MemberTermsConsentRepository.java
@@ -18,4 +18,8 @@ public interface MemberTermsConsentRepository extends JpaRepository<MemberTermsC
     @Modifying(clearAutomatically = true)
     @Query("UPDATE MemberTermsConsentEntity c SET c.agreedAt = :agreedAt WHERE c.memberId = :memberId AND c.termsVersionId IN :versionIds")
     void updateAgreedAt(@Param("memberId") Long memberId, @Param("versionIds") Collection<Long> versionIds, @Param("agreedAt") LocalDateTime agreedAt);
+
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM MemberTermsConsentEntity c WHERE c.memberId = :memberId AND c.termsVersionId IN :versionIds")
+    void deleteByMemberIdAndTermsVersionIdIn(@Param("memberId") Long memberId, @Param("versionIds") Collection<Long> versionIds);
 }

--- a/src/main/java/com/youthexpedition/azit/modules/member/adapter/out/persistence/repository/MemberTermsConsentRepository.java
+++ b/src/main/java/com/youthexpedition/azit/modules/member/adapter/out/persistence/repository/MemberTermsConsentRepository.java
@@ -1,0 +1,21 @@
+package com.youthexpedition.azit.modules.member.adapter.out.persistence.repository;
+
+import com.youthexpedition.azit.modules.member.adapter.out.persistence.entity.MemberTermsConsentEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.Collection;
+import java.util.Set;
+
+public interface MemberTermsConsentRepository extends JpaRepository<MemberTermsConsentEntity, Long> {
+
+    @Query("SELECT c.termsVersionId FROM MemberTermsConsentEntity c WHERE c.memberId = :memberId")
+    Set<Long> findTermsVersionIdsByMemberId(@Param("memberId") Long memberId);
+
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE MemberTermsConsentEntity c SET c.agreedAt = :agreedAt WHERE c.memberId = :memberId AND c.termsVersionId IN :versionIds")
+    void updateAgreedAt(@Param("memberId") Long memberId, @Param("versionIds") Collection<Long> versionIds, @Param("agreedAt") LocalDateTime agreedAt);
+}

--- a/src/main/java/com/youthexpedition/azit/modules/member/adapter/out/persistence/repository/MemberTermsConsentRepository.java
+++ b/src/main/java/com/youthexpedition/azit/modules/member/adapter/out/persistence/repository/MemberTermsConsentRepository.java
@@ -16,7 +16,7 @@ public interface MemberTermsConsentRepository extends JpaRepository<MemberTermsC
     Set<Long> findTermsVersionIdsByMemberId(@Param("memberId") Long memberId);
 
     @Modifying(clearAutomatically = true)
-    @Query("UPDATE MemberTermsConsentEntity c SET c.agreedAt = :agreedAt WHERE c.memberId = :memberId AND c.termsVersionId IN :versionIds")
+    @Query("UPDATE MemberTermsConsentEntity c SET c.agreedAt = :agreedAt, c.updatedAt = :agreedAt WHERE c.memberId = :memberId AND c.termsVersionId IN :versionIds")
     void updateAgreedAt(@Param("memberId") Long memberId, @Param("versionIds") Collection<Long> versionIds, @Param("agreedAt") LocalDateTime agreedAt);
 
     @Modifying(clearAutomatically = true)

--- a/src/main/java/com/youthexpedition/azit/modules/member/adapter/out/persistence/repository/TermsVersionRepository.java
+++ b/src/main/java/com/youthexpedition/azit/modules/member/adapter/out/persistence/repository/TermsVersionRepository.java
@@ -1,0 +1,20 @@
+package com.youthexpedition.azit.modules.member.adapter.out.persistence.repository;
+
+import com.youthexpedition.azit.modules.member.adapter.out.persistence.entity.TermsVersionEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+
+public interface TermsVersionRepository extends JpaRepository<TermsVersionEntity, Long> {
+
+    // 각 terms_type별 effective_at이 가장 최신인 버전 1건씩 조회
+    @Query("""
+            SELECT tv FROM TermsVersionEntity tv
+            WHERE tv.effectiveAt = (
+                SELECT MAX(tv2.effectiveAt) FROM TermsVersionEntity tv2
+                WHERE tv2.termsType = tv.termsType
+            )
+            """)
+    List<TermsVersionEntity> findAllLatest();
+}

--- a/src/main/java/com/youthexpedition/azit/modules/member/application/port/in/command/AgreeToTermsCommand.java
+++ b/src/main/java/com/youthexpedition/azit/modules/member/application/port/in/command/AgreeToTermsCommand.java
@@ -2,6 +2,7 @@ package com.youthexpedition.azit.modules.member.application.port.in.command;
 
 import com.youthexpedition.azit.infrastructure.exception.BusinessException;
 import com.youthexpedition.azit.modules.member.domain.model.enums.MemberErrorCode;
+import com.youthexpedition.azit.modules.member.domain.model.enums.TermsType;
 
 public record AgreeToTermsCommand(
         boolean serviceTermsAgreed,      // 서비스 이용약관 (필수)
@@ -16,6 +17,17 @@ public record AgreeToTermsCommand(
             boolean thirdPartyInfoAgreed, boolean marketingTermsAgreed, boolean notificationTermsAgreed) {
         return new AgreeToTermsCommand(
                 serviceTermsAgreed, privacyPolicyAgreed, locationServiceAgreed, thirdPartyInfoAgreed, marketingTermsAgreed, notificationTermsAgreed);
+    }
+
+    public boolean isAgreed(TermsType termsType) {
+        return switch (termsType) {
+            case SERVICE      -> serviceTermsAgreed;
+            case PRIVACY      -> privacyPolicyAgreed;
+            case LOCATION     -> locationServiceAgreed;
+            case THIRD_PARTY  -> thirdPartyInfoAgreed;
+            case MARKETING    -> marketingTermsAgreed;
+            case NOTIFICATION -> notificationTermsAgreed;
+        };
     }
 
     // 모든 필수 약관에 동의했는지 검증

--- a/src/main/java/com/youthexpedition/azit/modules/member/application/port/out/LoadTermsVersionPort.java
+++ b/src/main/java/com/youthexpedition/azit/modules/member/application/port/out/LoadTermsVersionPort.java
@@ -1,0 +1,11 @@
+package com.youthexpedition.azit.modules.member.application.port.out;
+
+import com.youthexpedition.azit.modules.member.domain.model.TermsVersion;
+
+import java.util.List;
+import java.util.Set;
+
+public interface LoadTermsVersionPort {
+    List<TermsVersion> findAllLatest();
+    Set<Long> findConsentedVersionIdsByMemberId(Long memberId);
+}

--- a/src/main/java/com/youthexpedition/azit/modules/member/application/port/out/SaveMemberTermsConsentPort.java
+++ b/src/main/java/com/youthexpedition/azit/modules/member/application/port/out/SaveMemberTermsConsentPort.java
@@ -10,5 +10,6 @@ import java.util.Set;
 public interface SaveMemberTermsConsentPort {
     void saveAll(List<MemberTermsConsent> consents);
     void updateAgreedAt(Long memberId, Set<Long> versionIds, LocalDateTime agreedAt);
+    void deleteByMemberIdAndVersionIds(Long memberId, Set<Long> versionIds);
     void saveAllHistory(List<MemberTermsConsentHistory> histories);
 }

--- a/src/main/java/com/youthexpedition/azit/modules/member/application/port/out/SaveMemberTermsConsentPort.java
+++ b/src/main/java/com/youthexpedition/azit/modules/member/application/port/out/SaveMemberTermsConsentPort.java
@@ -1,0 +1,14 @@
+package com.youthexpedition.azit.modules.member.application.port.out;
+
+import com.youthexpedition.azit.modules.member.domain.model.MemberTermsConsent;
+import com.youthexpedition.azit.modules.member.domain.model.MemberTermsConsentHistory;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Set;
+
+public interface SaveMemberTermsConsentPort {
+    void saveAll(List<MemberTermsConsent> consents);
+    void updateAgreedAt(Long memberId, Set<Long> versionIds, LocalDateTime agreedAt);
+    void saveAllHistory(List<MemberTermsConsentHistory> histories);
+}

--- a/src/main/java/com/youthexpedition/azit/modules/member/application/service/MemberService.java
+++ b/src/main/java/com/youthexpedition/azit/modules/member/application/service/MemberService.java
@@ -93,6 +93,16 @@ public class MemberService implements MemberUseCase {
             saveMemberTermsConsentPort.updateAgreedAt(memberId, reAgreedVersionIds, now);
         }
 
+        // 동의 철회: 기존에 동의했지만 이번 요청에서 미동의한 버전은 현재 상태 테이블에서 삭제
+        Set<Long> withdrawnVersionIds = latestVersions.stream()
+                .filter(v -> !command.isAgreed(v.getTermsType()))
+                .map(TermsVersion::getId)
+                .filter(alreadyConsentedVersionIds::contains)
+                .collect(Collectors.toSet());
+        if (!withdrawnVersionIds.isEmpty()) {
+            saveMemberTermsConsentPort.deleteByMemberIdAndVersionIds(memberId, withdrawnVersionIds);
+        }
+
         // 이력: 동의/미동의 여부와 관계없이 모든 최신 약관에 대해 저장
         List<MemberTermsConsentHistory> histories = latestVersions.stream()
                 .map(v -> MemberTermsConsentHistory.create(memberId, v.getId(), command.isAgreed(v.getTermsType())))

--- a/src/main/java/com/youthexpedition/azit/modules/member/application/service/MemberService.java
+++ b/src/main/java/com/youthexpedition/azit/modules/member/application/service/MemberService.java
@@ -21,9 +21,14 @@ import com.youthexpedition.azit.modules.member.application.port.in.dto.LinkedPro
 import com.youthexpedition.azit.modules.member.application.port.in.dto.MyCrewResponse;
 import com.youthexpedition.azit.modules.member.application.port.in.dto.MyInfoResponse;
 import com.youthexpedition.azit.modules.member.application.port.out.LoadMemberPort;
+import com.youthexpedition.azit.modules.member.application.port.out.LoadTermsVersionPort;
 import com.youthexpedition.azit.modules.member.application.port.out.SaveMemberPort;
+import com.youthexpedition.azit.modules.member.application.port.out.SaveMemberTermsConsentPort;
 import com.youthexpedition.azit.modules.member.application.service.mapper.MemberResponseMapper;
 import com.youthexpedition.azit.modules.member.domain.model.Member;
+import com.youthexpedition.azit.modules.member.domain.model.MemberTermsConsent;
+import com.youthexpedition.azit.modules.member.domain.model.MemberTermsConsentHistory;
+import com.youthexpedition.azit.modules.member.domain.model.TermsVersion;
 import com.youthexpedition.azit.modules.member.domain.model.enums.MemberErrorCode;
 import com.youthexpedition.azit.modules.member.domain.model.enums.SocialProvider;
 import lombok.RequiredArgsConstructor;
@@ -34,6 +39,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -51,6 +57,8 @@ public class MemberService implements MemberUseCase {
     private final TokenPort tokenPort;
     private final MemberResponseMapper memberResponseMapper;
     private final ImageUpdateUtil imageUpdateUtil;
+    private final LoadTermsVersionPort loadTermsVersionPort;
+    private final SaveMemberTermsConsentPort saveMemberTermsConsentPort;
 
     private static final String BLACKLIST_REASON_WITHDRAWN = "withdrawn";
 
@@ -62,7 +70,36 @@ public class MemberService implements MemberUseCase {
         Member member = getMember(memberId);
         member.completeTermsAgreement(command.marketingTermsAgreed(), command.notificationTermsAgreed()); // 멤버 상태 업데이트 (약관 동의)
         saveMemberPort.save(member);
+
+        List<TermsVersion> latestVersions = loadTermsVersionPort.findAllLatest();
+        Set<Long> alreadyConsentedVersionIds = loadTermsVersionPort.findConsentedVersionIdsByMemberId(memberId);
+        LocalDateTime now = LocalDateTime.now();
+
+        // 신규 버전: INSERT
+        List<MemberTermsConsent> newConsents = latestVersions.stream()
+                .filter(v -> command.isAgreed(v.getTermsType()))
+                .filter(v -> !alreadyConsentedVersionIds.contains(v.getId()))
+                .map(v -> MemberTermsConsent.agree(memberId, v.getId()))
+                .toList();
+        saveMemberTermsConsentPort.saveAll(newConsents);
+
+        // 기존 동의 버전 재동의: agreed_at, updated_at 갱신
+        Set<Long> reAgreedVersionIds = latestVersions.stream()
+                .filter(v -> command.isAgreed(v.getTermsType()))
+                .filter(v -> alreadyConsentedVersionIds.contains(v.getId()))
+                .map(TermsVersion::getId)
+                .collect(Collectors.toSet());
+        if (!reAgreedVersionIds.isEmpty()) {
+            saveMemberTermsConsentPort.updateAgreedAt(memberId, reAgreedVersionIds, now);
+        }
+
+        // 이력: 동의/미동의 여부와 관계없이 모든 최신 약관에 대해 저장
+        List<MemberTermsConsentHistory> histories = latestVersions.stream()
+                .map(v -> MemberTermsConsentHistory.create(memberId, v.getId(), command.isAgreed(v.getTermsType())))
+                .toList();
+        saveMemberTermsConsentPort.saveAllHistory(histories);
     }
+
 
     @Override
     @Transactional

--- a/src/main/java/com/youthexpedition/azit/modules/member/application/service/MemberService.java
+++ b/src/main/java/com/youthexpedition/azit/modules/member/application/service/MemberService.java
@@ -86,8 +86,8 @@ public class MemberService implements MemberUseCase {
         // 기존 동의 버전 재동의: agreed_at, updated_at 갱신
         Set<Long> reAgreedVersionIds = latestVersions.stream()
                 .filter(v -> command.isAgreed(v.getTermsType()))
-                .filter(v -> alreadyConsentedVersionIds.contains(v.getId()))
                 .map(TermsVersion::getId)
+                .filter(alreadyConsentedVersionIds::contains)
                 .collect(Collectors.toSet());
         if (!reAgreedVersionIds.isEmpty()) {
             saveMemberTermsConsentPort.updateAgreedAt(memberId, reAgreedVersionIds, now);

--- a/src/main/java/com/youthexpedition/azit/modules/member/domain/model/MemberTermsConsent.java
+++ b/src/main/java/com/youthexpedition/azit/modules/member/domain/model/MemberTermsConsent.java
@@ -1,0 +1,27 @@
+package com.youthexpedition.azit.modules.member.domain.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class MemberTermsConsent {
+    private final Long id;
+    private final Long memberId;
+    private final Long termsVersionId;
+    private final LocalDateTime agreedAt;
+    private final LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    public static MemberTermsConsent agree(Long memberId, Long termsVersionId) {
+        return MemberTermsConsent.builder()
+                .memberId(memberId)
+                .termsVersionId(termsVersionId)
+                .agreedAt(LocalDateTime.now())
+                .build();
+    }
+}

--- a/src/main/java/com/youthexpedition/azit/modules/member/domain/model/MemberTermsConsentHistory.java
+++ b/src/main/java/com/youthexpedition/azit/modules/member/domain/model/MemberTermsConsentHistory.java
@@ -14,14 +14,14 @@ public class MemberTermsConsentHistory {
     private final Long memberId;
     private final Long termsVersionId;
     private final boolean isAgreed;
-    private final LocalDateTime changedAt;
+    private final LocalDateTime createdAt;
+    private final LocalDateTime updatedAt;
 
     public static MemberTermsConsentHistory create(Long memberId, Long termsVersionId, boolean isAgreed) {
         return MemberTermsConsentHistory.builder()
                 .memberId(memberId)
                 .termsVersionId(termsVersionId)
                 .isAgreed(isAgreed)
-                .changedAt(LocalDateTime.now())
                 .build();
     }
 }

--- a/src/main/java/com/youthexpedition/azit/modules/member/domain/model/MemberTermsConsentHistory.java
+++ b/src/main/java/com/youthexpedition/azit/modules/member/domain/model/MemberTermsConsentHistory.java
@@ -1,0 +1,27 @@
+package com.youthexpedition.azit.modules.member.domain.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class MemberTermsConsentHistory {
+    private final Long id;
+    private final Long memberId;
+    private final Long termsVersionId;
+    private final boolean isAgreed;
+    private final LocalDateTime changedAt;
+
+    public static MemberTermsConsentHistory create(Long memberId, Long termsVersionId, boolean isAgreed) {
+        return MemberTermsConsentHistory.builder()
+                .memberId(memberId)
+                .termsVersionId(termsVersionId)
+                .isAgreed(isAgreed)
+                .changedAt(LocalDateTime.now())
+                .build();
+    }
+}

--- a/src/main/java/com/youthexpedition/azit/modules/member/domain/model/TermsVersion.java
+++ b/src/main/java/com/youthexpedition/azit/modules/member/domain/model/TermsVersion.java
@@ -1,0 +1,21 @@
+package com.youthexpedition.azit.modules.member.domain.model;
+
+import com.youthexpedition.azit.modules.member.domain.model.enums.TermsType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class TermsVersion {
+    private final Long id;
+    private final TermsType termsType;
+    private final String version;
+    private final boolean isRequired;
+    private final LocalDateTime effectiveAt;
+    private final LocalDateTime createdAt;
+    private final LocalDateTime updatedAt;
+}

--- a/src/main/java/com/youthexpedition/azit/modules/member/domain/model/enums/TermsType.java
+++ b/src/main/java/com/youthexpedition/azit/modules/member/domain/model/enums/TermsType.java
@@ -1,0 +1,10 @@
+package com.youthexpedition.azit.modules.member.domain.model.enums;
+
+public enum TermsType {
+    SERVICE,       // 서비스 이용약관 (필수)
+    PRIVACY,       // 개인정보 처리방침 (필수)
+    LOCATION,      // 위치기반 서비스 이용약관 (필수)
+    THIRD_PARTY,   // 제3자 정보제공 동의 (필수)
+    MARKETING,     // 마케팅 정보 수신 동의 (선택)
+    NOTIFICATION   // 알림 수신 동의 (선택)
+}

--- a/src/test/java/com/youthexpedition/azit/modules/auth/application/service/SocialLoginServiceTest.java
+++ b/src/test/java/com/youthexpedition/azit/modules/auth/application/service/SocialLoginServiceTest.java
@@ -1,0 +1,187 @@
+package com.youthexpedition.azit.modules.auth.application.service;
+
+import com.youthexpedition.azit.infrastructure.auth.jwt.JwtProvider;
+import com.youthexpedition.azit.modules.auth.application.port.in.command.SocialLoginCommand;
+import com.youthexpedition.azit.modules.auth.application.port.out.SocialAuthPort;
+import com.youthexpedition.azit.modules.auth.application.port.out.TokenPort;
+import com.youthexpedition.azit.modules.auth.domain.model.AuthResult;
+import com.youthexpedition.azit.modules.auth.domain.model.AuthToken;
+import com.youthexpedition.azit.modules.auth.domain.model.SocialProfile;
+import com.youthexpedition.azit.modules.crew.application.port.out.LoadCrewMemberPort;
+import com.youthexpedition.azit.modules.member.application.port.out.LoadMemberPort;
+import com.youthexpedition.azit.modules.member.application.port.out.LoadTermsVersionPort;
+import com.youthexpedition.azit.modules.member.application.port.out.SaveMemberPort;
+import com.youthexpedition.azit.modules.member.domain.model.Member;
+import com.youthexpedition.azit.modules.member.domain.model.TermsVersion;
+import com.youthexpedition.azit.modules.member.domain.model.enums.MemberRole;
+import com.youthexpedition.azit.modules.member.domain.model.enums.MemberStatus;
+import com.youthexpedition.azit.modules.member.domain.model.enums.SocialProvider;
+import com.youthexpedition.azit.modules.member.domain.model.enums.TermsType;
+import com.youthexpedition.azit.modules.member.domain.model.provider.ProfileImageProvider;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("SocialLoginService 단위 테스트")
+class SocialLoginServiceTest {
+
+    @Mock private SocialAuthPort socialAuthPort;
+    @Mock private LoadMemberPort loadMemberPort;
+    @Mock private SaveMemberPort saveMemberPort;
+    @Mock private TokenPort tokenPort;
+    @Mock private LoadCrewMemberPort loadCrewMemberPort;
+    @Mock private LoadTermsVersionPort loadTermsVersionPort;
+    @Mock private JwtProvider jwtProvider;
+    @Mock private ProfileImageProvider profileImageProvider;
+
+    @InjectMocks
+    private SocialLoginService socialLoginService;
+
+    @Nested
+    @DisplayName("약관 버전 체크")
+    class TermsUpdateCheck {
+
+        private final SocialLoginCommand command = new SocialLoginCommand(
+                SocialProvider.KAKAO, "authCode", null, null, null);
+
+        private final Member activeMember = Member.builder()
+                .id(1L)
+                .socialProvider(SocialProvider.KAKAO)
+                .socialProviderId("socialId")
+                .nickname("testUser")
+                .status(MemberStatus.ACTIVE)
+                .role(MemberRole.MEMBER)
+                .totalPoints(0L)
+                .totalAttendanceCount(0)
+                .build();
+
+        private final AuthToken authToken = AuthToken.builder()
+                .accessToken("accessToken")
+                .refreshToken("refreshToken")
+                .accessTokenExpiresIn(3600L)
+                .build();
+
+        private TermsVersion termsVersion(Long id, TermsType type, boolean isRequired) {
+            return TermsVersion.builder()
+                    .id(id)
+                    .termsType(type)
+                    .version("1.0")
+                    .isRequired(isRequired)
+                    .effectiveAt(LocalDateTime.of(2024, 1, 1, 0, 0))
+                    .createdAt(LocalDateTime.of(2024, 1, 1, 0, 0))
+                    .build();
+        }
+
+        private TermsVersion newTermsVersion(Long id, TermsType type) {
+            return TermsVersion.builder()
+                    .id(id)
+                    .termsType(type)
+                    .version("2.0")
+                    .isRequired(true)
+                    .effectiveAt(LocalDateTime.of(2026, 1, 1, 0, 0))
+                    .createdAt(LocalDateTime.of(2026, 1, 1, 0, 0))
+                    .build();
+        }
+
+        private void stubCommonLogin() {
+            SocialProfile profile = new SocialProfile("socialId", SocialProvider.KAKAO, "testUser", null, null, null, false);
+            doReturn(profile).when(socialAuthPort).getSocialProfile(any());
+            doReturn(Optional.of(activeMember)).when(loadMemberPort).findBySocialInfo(any(), any());
+            doReturn(activeMember).when(saveMemberPort).save(any());
+            doReturn(Optional.empty()).when(loadCrewMemberPort).findRecentJoinedCrewMember(any());
+            doReturn("accessToken").when(jwtProvider).generateAccessToken(any(), any(), any());
+            doReturn("refreshToken").when(jwtProvider).generateRefreshToken(any());
+            doReturn(3600L).when(jwtProvider).getAccessTokenExpirationSeconds();
+            doReturn(604800L).when(jwtProvider).getRefreshTokenExpirationSeconds();
+        }
+
+        @Test
+        @DisplayName("모든 필수 약관에 동의한 경우 needsTermsUpdate = false")
+        void login_needsTermsUpdate_false_whenAllRequiredTermsConsented() {
+            // given
+            stubCommonLogin();
+            List<TermsVersion> latestVersions = List.of(
+                    termsVersion(1L, TermsType.SERVICE, true),
+                    termsVersion(2L, TermsType.PRIVACY, true),
+                    termsVersion(3L, TermsType.LOCATION, true),
+                    termsVersion(4L, TermsType.THIRD_PARTY, true)
+            );
+            doReturn(latestVersions).when(loadTermsVersionPort).findAllLatest();
+            doReturn(Set.of(1L, 2L, 3L, 4L)).when(loadTermsVersionPort).findConsentedVersionIdsByMemberId(1L);
+
+            // when
+            AuthResult result = socialLoginService.login(command);
+
+            // then
+            assertFalse(result.needsTermsUpdate());
+        }
+
+        @Test
+        @DisplayName("새 버전 필수 약관에 미동의한 경우 needsTermsUpdate = true")
+        void login_needsTermsUpdate_true_whenNewRequiredTermsVersionExists() {
+            // given
+            stubCommonLogin();
+            List<TermsVersion> latestVersions = List.of(
+                    newTermsVersion(10L, TermsType.SERVICE), // v2.0 새 버전
+                    termsVersion(2L, TermsType.PRIVACY, true),
+                    termsVersion(3L, TermsType.LOCATION, true),
+                    termsVersion(4L, TermsType.THIRD_PARTY, true)
+            );
+            doReturn(latestVersions).when(loadTermsVersionPort).findAllLatest();
+            // 멤버는 v1.0(id=1)에만 동의, v2.0(id=10)에는 미동의
+            doReturn(Set.of(1L, 2L, 3L, 4L)).when(loadTermsVersionPort).findConsentedVersionIdsByMemberId(1L);
+
+            // when
+            AuthResult result = socialLoginService.login(command);
+
+            // then
+            assertTrue(result.needsTermsUpdate());
+        }
+
+        @Test
+        @DisplayName("PENDING_TERMS 상태 멤버는 약관 버전 체크 없이 needsTermsUpdate = false")
+        void login_needsTermsUpdate_false_whenMemberIsPendingTerms() {
+            // given
+            Member pendingMember = Member.builder()
+                    .id(2L)
+                    .socialProvider(SocialProvider.KAKAO)
+                    .socialProviderId("socialId2")
+                    .nickname("newUser")
+                    .status(MemberStatus.PENDING_TERMS)
+                    .role(MemberRole.MEMBER)
+                    .totalPoints(0L)
+                    .totalAttendanceCount(0)
+                    .build();
+
+            SocialProfile profile = new SocialProfile("socialId2", SocialProvider.KAKAO,  "newUser", null, null, null, false);
+            doReturn(profile).when(socialAuthPort).getSocialProfile(any());
+            doReturn(Optional.of(pendingMember)).when(loadMemberPort).findBySocialInfo(any(), any());
+            doReturn(pendingMember).when(saveMemberPort).save(any());
+            doReturn("accessToken").when(jwtProvider).generateAccessToken(any(), any(), any());
+            doReturn("refreshToken").when(jwtProvider).generateRefreshToken(any());
+            doReturn(3600L).when(jwtProvider).getAccessTokenExpirationSeconds();
+            doReturn(604800L).when(jwtProvider).getRefreshTokenExpirationSeconds();
+
+            // when
+            AuthResult result = socialLoginService.login(command);
+
+            // then
+            assertFalse(result.needsTermsUpdate());
+        }
+    }
+}

--- a/src/test/java/com/youthexpedition/azit/modules/auth/application/service/TokenManagementServiceTest.java
+++ b/src/test/java/com/youthexpedition/azit/modules/auth/application/service/TokenManagementServiceTest.java
@@ -1,6 +1,17 @@
 package com.youthexpedition.azit.modules.auth.application.service;
 
 import com.youthexpedition.azit.modules.auth.application.port.out.TokenPort;
+import com.youthexpedition.azit.modules.auth.application.port.out.TokenProviderPort;
+import com.youthexpedition.azit.modules.auth.domain.model.AuthResult;
+import com.youthexpedition.azit.modules.crew.application.port.out.LoadCrewMemberPort;
+import com.youthexpedition.azit.modules.member.application.port.out.LoadMemberPort;
+import com.youthexpedition.azit.modules.member.application.port.out.LoadTermsVersionPort;
+import com.youthexpedition.azit.modules.member.domain.model.Member;
+import com.youthexpedition.azit.modules.member.domain.model.TermsVersion;
+import com.youthexpedition.azit.modules.member.domain.model.enums.MemberRole;
+import com.youthexpedition.azit.modules.member.domain.model.enums.MemberStatus;
+import com.youthexpedition.azit.modules.member.domain.model.enums.SocialProvider;
+import com.youthexpedition.azit.modules.member.domain.model.enums.TermsType;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -9,22 +20,67 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("TokenManagementService 단위 테스트")
 class TokenManagementServiceTest {
-    @Mock
-    private TokenPort tokenPort;
+
+    @Mock private TokenPort tokenPort;
+    @Mock private TokenProviderPort tokenProviderPort;
+    @Mock private LoadMemberPort loadMemberPort;
+    @Mock private LoadCrewMemberPort loadCrewMemberPort;
+    @Mock private LoadTermsVersionPort loadTermsVersionPort;
 
     @InjectMocks
     private TokenManagementService tokenManagementService;
 
+    private final Member activeMember = Member.builder()
+            .id(1L)
+            .socialProvider(SocialProvider.KAKAO)
+            .socialProviderId("socialId")
+            .nickname("testUser")
+            .status(MemberStatus.ACTIVE)
+            .role(MemberRole.MEMBER)
+            .totalPoints(0L)
+            .totalAttendanceCount(0)
+            .build();
+
+    private TermsVersion termsVersion(Long id, TermsType type, boolean isRequired, String version) {
+        return TermsVersion.builder()
+                .id(id)
+                .termsType(type)
+                .version(version)
+                .isRequired(isRequired)
+                .effectiveAt(LocalDateTime.of(2024, 1, 1, 0, 0))
+                .createdAt(LocalDateTime.of(2024, 1, 1, 0, 0))
+                .build();
+    }
+
+    private void stubReissue(Member member) {
+        doReturn(true).when(tokenProviderPort).validateToken(any());
+        doReturn(member.getId()).when(tokenProviderPort).extractMemberId(any());
+        doReturn(Optional.of(member)).when(loadMemberPort).findById(member.getId());
+        doReturn("newAccessToken").when(tokenProviderPort).generateAccessToken(any(), any(), any());
+        doReturn("newRefreshToken").when(tokenProviderPort).generateRefreshToken(any());
+        doReturn(3600L).when(tokenProviderPort).getAccessTokenExpirationSeconds();
+        doReturn(604800L).when(tokenProviderPort).getRefreshTokenExpirationSeconds();
+        doReturn(true).when(tokenPort).compareAndRotate(any(), any(), any(), anyLong(), anyLong());
+        doReturn(Optional.empty()).when(loadCrewMemberPort).findRecentJoinedCrewMember(any());
+    }
 
     @Nested
     @DisplayName("로그아웃")
     class Logout {
+
         @Test
         @DisplayName("성공")
         void logout_success() {
@@ -38,6 +94,50 @@ class TokenManagementServiceTest {
             // then
             verify(tokenPort, times(1)).deleteByMemberId(memberId);
             verify(tokenPort, times(1)).addToBlacklist(accessToken, "logout");
+        }
+    }
+
+    @Nested
+    @DisplayName("토큰 재발급 - 약관 버전 체크")
+    class ReissueTermsCheck {
+
+        @Test
+        @DisplayName("모든 필수 약관에 동의한 경우 needsTermsUpdate = false")
+        void reissue_needsTermsUpdate_false_whenAllRequiredTermsConsented() {
+            // given
+            stubReissue(activeMember);
+            List<TermsVersion> latestVersions = List.of(
+                    termsVersion(1L, TermsType.SERVICE, true, "1.0"),
+                    termsVersion(2L, TermsType.PRIVACY, true, "1.0")
+            );
+            doReturn(latestVersions).when(loadTermsVersionPort).findAllLatest();
+            doReturn(Set.of(1L, 2L)).when(loadTermsVersionPort).findConsentedVersionIdsByMemberId(1L);
+
+            // when
+            AuthResult result = tokenManagementService.reissue("refreshToken");
+
+            // then
+            assertFalse(result.needsTermsUpdate());
+        }
+
+        @Test
+        @DisplayName("토큰 재발급 중 새 버전 필수 약관 배포 시 needsTermsUpdate = true")
+        void reissue_needsTermsUpdate_true_whenNewRequiredTermsVersionReleasedDuringSession() {
+            // given
+            stubReissue(activeMember);
+            List<TermsVersion> latestVersions = List.of(
+                    termsVersion(10L, TermsType.SERVICE, true, "2.0"), // 새 버전 배포
+                    termsVersion(2L, TermsType.PRIVACY, true, "1.0")
+            );
+            doReturn(latestVersions).when(loadTermsVersionPort).findAllLatest();
+            // 멤버는 v1.0(id=1)에만 동의, 새로 배포된 v2.0(id=10)에는 미동의
+            doReturn(Set.of(1L, 2L)).when(loadTermsVersionPort).findConsentedVersionIdsByMemberId(1L);
+
+            // when
+            AuthResult result = tokenManagementService.reissue("refreshToken");
+
+            // then
+            assertTrue(result.needsTermsUpdate());
         }
     }
 }

--- a/src/test/java/com/youthexpedition/azit/modules/member/application/service/MemberServiceTest.java
+++ b/src/test/java/com/youthexpedition/azit/modules/member/application/service/MemberServiceTest.java
@@ -15,12 +15,20 @@ import com.youthexpedition.azit.modules.image.domain.model.enums.ImageErrorCode;
 import com.youthexpedition.azit.modules.member.application.port.in.command.UpdateMemberProfileCommand;
 import com.youthexpedition.azit.modules.member.application.port.in.dto.MyCrewResponse;
 import com.youthexpedition.azit.modules.member.application.port.out.LoadMemberPort;
+import com.youthexpedition.azit.modules.member.application.port.out.LoadTermsVersionPort;
 import com.youthexpedition.azit.modules.member.application.port.out.SaveMemberPort;
+import com.youthexpedition.azit.modules.member.application.port.out.SaveMemberTermsConsentPort;
 import com.youthexpedition.azit.modules.member.application.service.mapper.MemberResponseMapper;
 import com.youthexpedition.azit.modules.member.domain.model.Member;
 import com.youthexpedition.azit.modules.member.application.port.in.command.AgreeToTermsCommand;
+import com.youthexpedition.azit.modules.member.domain.model.MemberTermsConsent;
+import com.youthexpedition.azit.modules.member.domain.model.MemberTermsConsentHistory;
+import com.youthexpedition.azit.modules.member.domain.model.TermsVersion;
 import com.youthexpedition.azit.modules.member.domain.model.enums.MemberErrorCode;
 import com.youthexpedition.azit.modules.member.domain.model.enums.SocialProvider;
+import com.youthexpedition.azit.modules.member.domain.model.enums.TermsType;
+
+import java.time.LocalDateTime;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -66,6 +74,10 @@ class MemberServiceTest {
     private MemberResponseMapper memberResponseMapper;
     @Mock
     private ImageUpdateUtil imageUpdateUtil;
+    @Mock
+    private LoadTermsVersionPort loadTermsVersionPort;
+    @Mock
+    private SaveMemberTermsConsentPort saveMemberTermsConsentPort;
 
     @InjectMocks
     private MemberService memberService;
@@ -173,30 +185,68 @@ class MemberServiceTest {
         private final Long memberId = 1L;
         private final Member member = Member.create(SocialProvider.KAKAO, "socialId", "test@example.com", "password", true, "nickname");
 
+        private final List<TermsVersion> allLatestVersions = List.of(
+                termsVersion(1L, TermsType.SERVICE, true),
+                termsVersion(2L, TermsType.PRIVACY, true),
+                termsVersion(3L, TermsType.LOCATION, true),
+                termsVersion(4L, TermsType.THIRD_PARTY, true),
+                termsVersion(5L, TermsType.MARKETING, false),
+                termsVersion(6L, TermsType.NOTIFICATION, false)
+        );
+
         @Test
-        @DisplayName("성공")
-        void agreeToTerms_success() {
+        @DisplayName("성공 - 선택 약관 포함 전체 동의")
+        void agreeToTerms_success_withAllTermsAgreed() {
             // given
             AgreeToTermsCommand command = new AgreeToTermsCommand(true, true, true, true, true, true);
             doReturn(Optional.of(member)).when(loadMemberPort).findById(memberId);
             doReturn(member).when(saveMemberPort).save(any(Member.class));
+            doReturn(allLatestVersions).when(loadTermsVersionPort).findAllLatest();
 
             // when
             memberService.agreeToTerms(memberId, command);
 
             // then
-            verify(loadMemberPort, times(1)).findById(memberId);
             verify(saveMemberPort, times(1)).save(member);
+            verify(saveMemberTermsConsentPort, times(1)).saveAll(argThat(consents ->
+                    consents.size() == 6 // 전체 6종 동의
+            ));
+            verify(saveMemberTermsConsentPort, times(1)).saveAllHistory(argThat(histories ->
+                    histories.size() == 6 && histories.stream().allMatch(MemberTermsConsentHistory::isAgreed)
+            ));
             assertTrue(member.isMarketingTermsAgreed());
             assertTrue(member.isNotificationAgreed());
             assertNotNull(member.getEssentialTermsAgreedAt());
         }
 
         @Test
+        @DisplayName("성공 - 선택 약관 미동의 시 consent는 저장되지 않고 history에만 미동의 이력 저장")
+        void agreeToTerms_success_withOptionalTermsDeclined() {
+            // given
+            AgreeToTermsCommand command = new AgreeToTermsCommand(true, true, true, true, false, false);
+            doReturn(Optional.of(member)).when(loadMemberPort).findById(memberId);
+            doReturn(member).when(saveMemberPort).save(any(Member.class));
+            doReturn(allLatestVersions).when(loadTermsVersionPort).findAllLatest();
+
+            // when
+            memberService.agreeToTerms(memberId, command);
+
+            // then
+            verify(saveMemberTermsConsentPort, times(1)).saveAll(argThat(consents ->
+                    consents.size() == 4 // 필수 4종만 저장
+            ));
+            verify(saveMemberTermsConsentPort, times(1)).saveAllHistory(argThat(histories ->
+                    histories.size() == 6 // 전체 6종 이력 저장
+                    && histories.stream().filter(h -> !h.isAgreed()).count() == 2 // 미동의 2건 포함
+            ));
+            assertFalse(member.isMarketingTermsAgreed());
+            assertFalse(member.isNotificationAgreed());
+        }
+
+        @Test
         @DisplayName("실패 - 필수 약관 미동의")
         void agreeToTerms_fail_requiredTermsNotAgreed() {
             // given
-            // 서비스 이용약관(serviceTermsAgreed)을 false로 설정
             AgreeToTermsCommand command = new AgreeToTermsCommand(false, true, true, true, false, false);
 
             // when & then
@@ -207,6 +257,19 @@ class MemberServiceTest {
             assertEquals(MemberErrorCode.REQUIRED_TERMS_NOT_AGREED, exception.getErrorCode());
             verify(loadMemberPort, never()).findById(anyLong());
             verify(saveMemberPort, never()).save(any(Member.class));
+            verify(loadTermsVersionPort, never()).findAllLatest();
+            verify(saveMemberTermsConsentPort, never()).saveAll(any());
+        }
+
+        private TermsVersion termsVersion(Long id, TermsType type, boolean isRequired) {
+            return TermsVersion.builder()
+                    .id(id)
+                    .termsType(type)
+                    .version("1.0")
+                    .isRequired(isRequired)
+                    .effectiveAt(LocalDateTime.of(2024, 1, 1, 0, 0))
+                    .createdAt(LocalDateTime.of(2024, 1, 1, 0, 0))
+                    .build();
         }
     }
 

--- a/src/test/java/com/youthexpedition/azit/modules/member/application/service/MemberServiceTest.java
+++ b/src/test/java/com/youthexpedition/azit/modules/member/application/service/MemberServiceTest.java
@@ -12,6 +12,7 @@ import com.youthexpedition.azit.modules.crew.domain.model.CrewMember;
 import com.youthexpedition.azit.modules.crew.domain.model.enums.CrewMemberRole;
 import com.youthexpedition.azit.modules.crew.domain.model.enums.CrewMemberStatus;
 import com.youthexpedition.azit.modules.image.domain.model.enums.ImageErrorCode;
+import com.youthexpedition.azit.modules.member.application.port.in.command.AgreeToTermsCommand;
 import com.youthexpedition.azit.modules.member.application.port.in.command.UpdateMemberProfileCommand;
 import com.youthexpedition.azit.modules.member.application.port.in.dto.MyCrewResponse;
 import com.youthexpedition.azit.modules.member.application.port.out.LoadMemberPort;
@@ -20,15 +21,11 @@ import com.youthexpedition.azit.modules.member.application.port.out.SaveMemberPo
 import com.youthexpedition.azit.modules.member.application.port.out.SaveMemberTermsConsentPort;
 import com.youthexpedition.azit.modules.member.application.service.mapper.MemberResponseMapper;
 import com.youthexpedition.azit.modules.member.domain.model.Member;
-import com.youthexpedition.azit.modules.member.application.port.in.command.AgreeToTermsCommand;
-import com.youthexpedition.azit.modules.member.domain.model.MemberTermsConsent;
 import com.youthexpedition.azit.modules.member.domain.model.MemberTermsConsentHistory;
 import com.youthexpedition.azit.modules.member.domain.model.TermsVersion;
 import com.youthexpedition.azit.modules.member.domain.model.enums.MemberErrorCode;
 import com.youthexpedition.azit.modules.member.domain.model.enums.SocialProvider;
 import com.youthexpedition.azit.modules.member.domain.model.enums.TermsType;
-
-import java.time.LocalDateTime;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -37,20 +34,18 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Consumer;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.BDDMockito.given;
-
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.argThat;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("MemberService 단위 테스트")
@@ -241,6 +236,48 @@ class MemberServiceTest {
             ));
             assertFalse(member.isMarketingTermsAgreed());
             assertFalse(member.isNotificationAgreed());
+        }
+
+        @Test
+        @DisplayName("성공 - 기존 동의한 선택 약관 철회 시 consent 삭제 및 철회 이력 저장")
+        void agreeToTerms_success_withOptionalTermsWithdrawn() {
+            // given - 이전에 전체(필수 4종 + 선택 2종) 동의한 상태에서 선택 약관만 철회
+            AgreeToTermsCommand command = new AgreeToTermsCommand(true, true, true, true, false, false);
+            doReturn(Optional.of(member)).when(loadMemberPort).findById(memberId);
+            doReturn(member).when(saveMemberPort).save(any(Member.class));
+            doReturn(allLatestVersions).when(loadTermsVersionPort).findAllLatest();
+            doReturn(Set.of(1L, 2L, 3L, 4L, 5L, 6L)).when(loadTermsVersionPort).findConsentedVersionIdsByMemberId(memberId);
+
+            // when
+            memberService.agreeToTerms(memberId, command);
+
+            // then
+            verify(saveMemberTermsConsentPort, times(1)).saveAll(argThat(List::isEmpty)); // 신규 INSERT 없음
+            verify(saveMemberTermsConsentPort, times(1)).updateAgreedAt(eq(memberId), eq(Set.of(1L, 2L, 3L, 4L)), any()); // 필수 4종 재동의 갱신
+            verify(saveMemberTermsConsentPort, times(1)).deleteByMemberIdAndVersionIds(memberId, Set.of(5L, 6L)); // 선택 2종 철회 삭제
+            verify(saveMemberTermsConsentPort, times(1)).saveAllHistory(argThat(histories ->
+                    histories.size() == 6
+                    && histories.stream().filter(h -> !h.isAgreed()).count() == 2 // 철회 이력 2건 포함
+            ));
+            assertFalse(member.isMarketingTermsAgreed());
+            assertFalse(member.isNotificationAgreed());
+        }
+
+        @Test
+        @DisplayName("성공 - 기존에 미동의한 선택 약관은 철회 삭제 대상이 아님")
+        void agreeToTerms_success_noDeleteWhenNeverConsented() {
+            // given - 필수 4종만 동의된 상태에서 동일하게 재동의 (선택 약관은 원래 미동의)
+            AgreeToTermsCommand command = new AgreeToTermsCommand(true, true, true, true, false, false);
+            doReturn(Optional.of(member)).when(loadMemberPort).findById(memberId);
+            doReturn(member).when(saveMemberPort).save(any(Member.class));
+            doReturn(allLatestVersions).when(loadTermsVersionPort).findAllLatest();
+            doReturn(Set.of(1L, 2L, 3L, 4L)).when(loadTermsVersionPort).findConsentedVersionIdsByMemberId(memberId);
+
+            // when
+            memberService.agreeToTerms(memberId, command);
+
+            // then
+            verify(saveMemberTermsConsentPort, never()).deleteByMemberIdAndVersionIds(anyLong(), any()); // 삭제할 동의 레코드 없음
         }
 
         @Test


### PR DESCRIPTION
## 📌 관련 이슈
- #187

## ✨ 작업 내용
> 이번 PR에서 변경된 핵심 내용을 요약해주세요.

- 약관 버전 관리 테이블(`terms_version`, `member_terms_consent`, `member_terms_consent_history`) 설계 및 구현
- 로그인·토큰 재발급 시 필수 약관 최신 버전 동의 여부를 체크하여 응답에 `needsTermsUpdate` 필드 추가
- 약관 동의(`agreeToTerms`) 로직 개선 — 최신 버전 기준 신규 INSERT / 기존 버전 `agreed_at` UPDATE / 전체 이력 저장

## 🧱 아키텍처 변경 요약
> 이번 작업으로 인해 변경된 주요 흐름을 적어주세요. (없으면 생략 가능)

**신규 추가**
- Domain: `TermsType`, `TermsVersion`, `MemberTermsConsent`, `MemberTermsConsentHistory`
- Port: `LoadTermsVersionPort`, `SaveMemberTermsConsentPort`
- Entity: `TermsVersionEntity`, `MemberTermsConsentEntity`, `MemberTermsConsentHistoryEntity`
- Adapter: `TermsPersistenceAdapter` (두 Port 구현)
- Mapper: `TermsVersionMapper`, `MemberTermsConsentMapper`, `MemberTermsConsentHistoryMapper`

**수정**
- `AgreeToTermsCommand` — `isAgreed(TermsType)` 메서드 추가 (switch 책임 이동)
- `MemberService.agreeToTerms` — 버전 기반 동의 이력 저장 로직 추가
- `SocialLoginService.login` / `TokenManagementService.reissue` — 약관 버전 체크 후 `needsTermsUpdate` 반환
- `AuthResult`, `SocialLoginResponse` — `needsTermsUpdate` 필드 추가

**로그인 흐름 변경**
→ ACTIVE 멤버인 경우 필수 약관 최신 버전 조회
→ 미동의 버전 존재 시 needsTermsUpdate: true 반환
→ 프론트에서 재동의 화면으로 유도

## 📸 스크린샷 (선택 사항)
> API 테스트 결과 등을 첨부해주세요.

## ⚠️ 주의 사항 (선택)
- [x] DB 스키마 변경이 있나요?
- [x] API 명세(Swagger)가 업데이트 되었나요?
- [ ] 새로운 환경 변수(.env)가 추가 되었나요?

## ✅ 셀프 체크리스트
- [ ] 브랜치 전략(develop)에 맞게 올렸나요?
- [ ] 커밋 컨벤션을 준수했나요?
- [ ] 불필요한 주석이나 print문은 제거했나요?
- [ ] 로컬에서 테스트는 성공했나요?