### PR TITLE
[REFACTOR] 크루 멤버 수 업데이트 로직 원자적 업데이트 구현

### DIFF
--- a/src/main/java/com/youthexpedition/azit/modules/crew/adapter/out/persistence/CrewPersistenceAdapter.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/adapter/out/persistence/CrewPersistenceAdapter.java
@@ -54,4 +54,9 @@ public class CrewPersistenceAdapter implements LoadCrewPort, SaveCrewPort {
                 .toList();
         crewRepository.saveAll(entities);
     }
+
+    @Override
+    public void incrementMemberCount(Long crewId) {
+        crewRepository.incrementMemberCount(crewId);
+    }
 }

--- a/src/main/java/com/youthexpedition/azit/modules/crew/adapter/out/persistence/CrewPersistenceAdapter.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/adapter/out/persistence/CrewPersistenceAdapter.java
@@ -64,4 +64,9 @@ public class CrewPersistenceAdapter implements LoadCrewPort, SaveCrewPort {
     public void decrementMemberCount(Long crewId) {
         crewRepository.decrementMemberCount(crewId);
     }
+
+    @Override
+    public void decrementMemberCountBatch(List<Long> crewIds) {
+        crewRepository.decrementMemberCountBatch(crewIds);
+    }
 }

--- a/src/main/java/com/youthexpedition/azit/modules/crew/adapter/out/persistence/CrewPersistenceAdapter.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/adapter/out/persistence/CrewPersistenceAdapter.java
@@ -67,6 +67,7 @@ public class CrewPersistenceAdapter implements LoadCrewPort, SaveCrewPort {
 
     @Override
     public void decrementMemberCountBatch(List<Long> crewIds) {
+        if (crewIds == null || crewIds.isEmpty()) return;
         crewRepository.decrementMemberCountBatch(crewIds);
     }
 }

--- a/src/main/java/com/youthexpedition/azit/modules/crew/adapter/out/persistence/CrewPersistenceAdapter.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/adapter/out/persistence/CrewPersistenceAdapter.java
@@ -59,4 +59,9 @@ public class CrewPersistenceAdapter implements LoadCrewPort, SaveCrewPort {
     public void incrementMemberCount(Long crewId) {
         crewRepository.incrementMemberCount(crewId);
     }
+
+    @Override
+    public void decrementMemberCount(Long crewId) {
+        crewRepository.decrementMemberCount(crewId);
+    }
 }

--- a/src/main/java/com/youthexpedition/azit/modules/crew/adapter/out/persistence/repository/CrewRepository.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/adapter/out/persistence/repository/CrewRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface CrewRepository extends JpaRepository<CrewEntity, Long> {
@@ -19,4 +20,8 @@ public interface CrewRepository extends JpaRepository<CrewEntity, Long> {
     @Modifying
     @Query("UPDATE CrewEntity c SET c.memberCount = c.memberCount - 1 WHERE c.id = :crewId")
     void decrementMemberCount(@Param("crewId") Long crewId);
+
+    @Modifying
+    @Query("UPDATE CrewEntity c SET c.memberCount = c.memberCount - 1 WHERE c.id IN :crewIds")
+    void decrementMemberCountBatch(@Param("crewIds") List<Long> crewIds);
 }

--- a/src/main/java/com/youthexpedition/azit/modules/crew/adapter/out/persistence/repository/CrewRepository.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/adapter/out/persistence/repository/CrewRepository.java
@@ -2,10 +2,17 @@ package com.youthexpedition.azit.modules.crew.adapter.out.persistence.repository
 
 import com.youthexpedition.azit.modules.crew.adapter.out.persistence.entity.CrewEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface CrewRepository extends JpaRepository<CrewEntity, Long> {
     Optional<CrewEntity> findByInvitationCode(String invitationCode);
     boolean existsByInvitationCode(String invitationCode);
+
+    @Modifying
+    @Query("UPDATE CrewEntity c SET c.memberCount = c.memberCount + 1 WHERE c.id = :crewId")
+    void incrementMemberCount(@Param("crewId") Long crewId);
 }

--- a/src/main/java/com/youthexpedition/azit/modules/crew/adapter/out/persistence/repository/CrewRepository.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/adapter/out/persistence/repository/CrewRepository.java
@@ -13,15 +13,15 @@ public interface CrewRepository extends JpaRepository<CrewEntity, Long> {
     Optional<CrewEntity> findByInvitationCode(String invitationCode);
     boolean existsByInvitationCode(String invitationCode);
 
-    @Modifying
+    @Modifying(clearAutomatically = true)
     @Query("UPDATE CrewEntity c SET c.memberCount = c.memberCount + 1 WHERE c.id = :crewId")
     void incrementMemberCount(@Param("crewId") Long crewId);
 
-    @Modifying
+    @Modifying(clearAutomatically = true)
     @Query("UPDATE CrewEntity c SET c.memberCount = c.memberCount - 1 WHERE c.id = :crewId")
     void decrementMemberCount(@Param("crewId") Long crewId);
 
-    @Modifying
+    @Modifying(clearAutomatically = true)
     @Query("UPDATE CrewEntity c SET c.memberCount = c.memberCount - 1 WHERE c.id IN :crewIds")
     void decrementMemberCountBatch(@Param("crewIds") List<Long> crewIds);
 }

--- a/src/main/java/com/youthexpedition/azit/modules/crew/adapter/out/persistence/repository/CrewRepository.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/adapter/out/persistence/repository/CrewRepository.java
@@ -15,4 +15,8 @@ public interface CrewRepository extends JpaRepository<CrewEntity, Long> {
     @Modifying
     @Query("UPDATE CrewEntity c SET c.memberCount = c.memberCount + 1 WHERE c.id = :crewId")
     void incrementMemberCount(@Param("crewId") Long crewId);
+
+    @Modifying
+    @Query("UPDATE CrewEntity c SET c.memberCount = c.memberCount - 1 WHERE c.id = :crewId")
+    void decrementMemberCount(@Param("crewId") Long crewId);
 }

--- a/src/main/java/com/youthexpedition/azit/modules/crew/application/port/out/SaveCrewPort.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/application/port/out/SaveCrewPort.java
@@ -7,4 +7,5 @@ import java.util.List;
 public interface SaveCrewPort {
     Crew save(Crew crew);
     void saveAll(List<Crew> crews);
+    void incrementMemberCount(Long crewId);
 }

--- a/src/main/java/com/youthexpedition/azit/modules/crew/application/port/out/SaveCrewPort.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/application/port/out/SaveCrewPort.java
@@ -8,4 +8,5 @@ public interface SaveCrewPort {
     Crew save(Crew crew);
     void saveAll(List<Crew> crews);
     void incrementMemberCount(Long crewId);
+    void decrementMemberCount(Long crewId);
 }

--- a/src/main/java/com/youthexpedition/azit/modules/crew/application/port/out/SaveCrewPort.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/application/port/out/SaveCrewPort.java
@@ -9,4 +9,5 @@ public interface SaveCrewPort {
     void saveAll(List<Crew> crews);
     void incrementMemberCount(Long crewId);
     void decrementMemberCount(Long crewId);
+    void decrementMemberCountBatch(List<Long> crewIds);
 }

--- a/src/main/java/com/youthexpedition/azit/modules/crew/application/service/CrewService.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/application/service/CrewService.java
@@ -196,11 +196,8 @@ public class CrewService implements CrewUseCase {
         targetCrewMember.approve();
         saveCrewMemberPort.save(targetCrewMember);
 
-        Crew crew = loadCrewPort.findById(command.crewId())
-                .orElseThrow(() -> new BusinessException(CrewErrorCode.CREW_NOT_FOUND));
-
         // 크루 인원 수 증가
-        log.info("[CREW] crewId: {} 에서 memberId: {} 가 가입되어 크루 인원 수가 증가합니다.", crew.getId(), command.targetMemberId());
+        log.info("[CREW] crewId: {} 에서 memberId: {} 가 가입되어 크루 인원 수가 증가합니다.", command.crewId(), command.targetMemberId());
         saveCrewPort.incrementMemberCount(command.crewId());
     }
 

--- a/src/main/java/com/youthexpedition/azit/modules/crew/application/service/CrewService.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/application/service/CrewService.java
@@ -199,7 +199,7 @@ public class CrewService implements CrewUseCase {
         Crew crew = loadCrewPort.findById(command.crewId())
                 .orElseThrow(() -> new BusinessException(CrewErrorCode.CREW_NOT_FOUND));
 
-        // 크루 인원 수 증가 (Atomic UPDATE로 동시성 보장)
+        // 크루 인원 수 증가
         log.info("[CREW] crewId: {} 에서 memberId: {} 가 가입되어 크루 인원 수가 증가합니다.", crew.getId(), command.targetMemberId());
         saveCrewPort.incrementMemberCount(command.crewId());
     }
@@ -264,13 +264,8 @@ public class CrewService implements CrewUseCase {
         saveCrewMemberPort.save(targetMember);
 
         // 크루 인원 수 1명 감소
-        // TODO: 동시성 이슈 고려 필요
-        Crew crew = loadCrewPort.findById(crewId)
-                .orElseThrow(() -> new BusinessException(CrewErrorCode.CREW_NOT_FOUND));
-
         log.info("[CREW] crewId: {} 에서 memberId: {} 가 방출되어 크루 인원 수가 감소합니다.", crewId, targetMemberId);
-        crew.decreaseMemberCount();
-        saveCrewPort.save(crew);
+        saveCrewPort.decrementMemberCount(crewId);
     }
 
     @Override
@@ -308,12 +303,8 @@ public class CrewService implements CrewUseCase {
         saveCrewMemberPort.save(crewMember);
 
         // 크루 인원 수 1명 감소
-        Crew crew = loadCrewPort.findById(crewId)
-                .orElseThrow(() -> new BusinessException(CrewErrorCode.CREW_NOT_FOUND));
-
         log.info("[CREW] crewId: {} 에서 memberId: {} 가 자진 탈퇴하여 크루 인원 수가 감소합니다.", crewId, memberId);
-        crew.decreaseMemberCount();
-        saveCrewPort.save(crew);
+        saveCrewPort.decrementMemberCount(crewId);
     }
 
     @Override

--- a/src/main/java/com/youthexpedition/azit/modules/crew/application/service/CrewService.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/application/service/CrewService.java
@@ -196,14 +196,12 @@ public class CrewService implements CrewUseCase {
         targetCrewMember.approve();
         saveCrewMemberPort.save(targetCrewMember);
 
-        // 크루 인원 수 증가
-        // TODO: 원자성 체크 필요
         Crew crew = loadCrewPort.findById(command.crewId())
                 .orElseThrow(() -> new BusinessException(CrewErrorCode.CREW_NOT_FOUND));
 
+        // 크루 인원 수 증가 (Atomic UPDATE로 동시성 보장)
         log.info("[CREW] crewId: {} 에서 memberId: {} 가 가입되어 크루 인원 수가 증가합니다.", crew.getId(), command.targetMemberId());
-        crew.increaseMemberCount(); // 인원 수 +1
-        saveCrewPort.save(crew);
+        saveCrewPort.incrementMemberCount(command.crewId());
     }
 
     @Override

--- a/src/main/java/com/youthexpedition/azit/modules/member/application/service/MemberService.java
+++ b/src/main/java/com/youthexpedition/azit/modules/member/application/service/MemberService.java
@@ -229,10 +229,7 @@ public class MemberService implements MemberUseCase {
         // 인원수 일괄 차감
         if (!joinedCrewIds.isEmpty()) {
             log.info("[MEMBER] memberId: {}, crewIds : {} 탈퇴하여 인원수가 차감됩니다.", memberId, joinedCrewIds);
-
-            List<Crew> joinedCrews = loadCrewPort.findAllByIds(joinedCrewIds);
-            joinedCrews.forEach(Crew::decreaseMemberCount);
-            saveCrewPort.saveAll(joinedCrews);
+            saveCrewPort.decrementMemberCountBatch(joinedCrewIds);
         }
 
         // 가입한 모든 크루 상태를 EXITED로 변경 및 저장

--- a/src/main/java/com/youthexpedition/azit/modules/test/application/service/TestMemberService.java
+++ b/src/main/java/com/youthexpedition/azit/modules/test/application/service/TestMemberService.java
@@ -97,9 +97,7 @@ public class TestMemberService implements TestMemberUseCase {
 
         if (!joinedCrewIds.isEmpty()) {
             log.info("[TEST] memberId: {}, crewIds: {} 탈퇴로 인해 인원수가 차감됩니다.", memberId, joinedCrewIds);
-            List<Crew> joinedCrews = loadCrewPort.findAllByIds(joinedCrewIds);
-            joinedCrews.forEach(Crew::decreaseMemberCount);
-            saveCrewPort.saveAll(joinedCrews);
+            saveCrewPort.decrementMemberCountBatch(joinedCrewIds);
         }
     }
 

--- a/src/test/java/com/youthexpedition/azit/modules/crew/application/service/CrewServiceTest.java
+++ b/src/test/java/com/youthexpedition/azit/modules/crew/application/service/CrewServiceTest.java
@@ -358,18 +358,13 @@ class CrewServiceTest {
                     .status(CrewMemberStatus.REQUESTED).build();
             given(loadCrewMemberPort.findByCrewIdAndMemberId(crewId, targetMemberId)).willReturn(Optional.of(targetCrewMember));
 
-            Crew mockCrew = Crew.builder()
-                    .id(crewId)
-                    .memberCount(0)
-                    .build();
-            given(loadCrewPort.findById(crewId)).willReturn(Optional.of(mockCrew));
-
             // when
             crewService.approveJoinRequest(command);
 
             // then
-            assertThat(targetCrewMember.getStatus()).isEqualTo(CrewMemberStatus.JOINED); // 크루 상태 변경 확인
+            assertThat(targetCrewMember.getStatus()).isEqualTo(CrewMemberStatus.JOINED);
             verify(saveCrewMemberPort, times(1)).save(targetCrewMember);
+            verify(saveCrewPort, times(1)).incrementMemberCount(crewId);
         }
 
         @Test


### PR DESCRIPTION
## 📌 관련 이슈
- #76

## ✨ 작업 내용

- `approveJoinRequest`: 가입 승인 시 `memberCount` 증가를 load-modify-save 패턴에서 Atomic UPDATE로 교체
- `exitCrew`: 자진 탈퇴 시 `memberCount` 감소를 Atomic UPDATE로 교체
- `expelCrewMember`: 방출 시 `memberCount` 감소를 Atomic UPDATE로 교체
- `MemberService`, `TestMemberService`: 서비스 탈퇴 시 다수 크루 `memberCount` 일괄 감소를 `IN` 절 Atomic UPDATE로 교체

## 🧱 아키텍처 변경 요약

- `SaveCrewPort`에 `incrementMemberCount`, `decrementMemberCount`, `decrementMemberCountBatch` 메서드 추가
- `CrewRepository`에 `@Modifying` JPQL UPDATE 쿼리 3개 추가
- `CrewPersistenceAdapter`에 위 포트 구현체 추가

## 배경

기존 load-modify-save 패턴은 두 트랜잭션이 동시에 같은 `memberCount`를 읽고 각자 +1/-1하면 Lost Update가 발생할 수 있었습니다.
`UPDATE crew SET member_count = member_count ± 1 WHERE id = ?` 단일 쿼리로 교체하여 DB 엔진이 원자적으로 처리하도록 변경했습니다.
Optimistic Locking(`@Version`) 대비 추가 컬럼 불필요, 클라이언트 재시도 불필요, 불필요한 SELECT 제거 등 이점이 있습니다.

## ⚠️ 주의 사항
- [ ] DB 스키마 변경 없음
- [ ] API 명세 변경 없음
- [ ] 환경 변수 변경 없음

## ✅ 셀프 체크리스트
- [x] 브랜치 전략(develop)에 맞게 올렸나요?
- [x] 커밋 컨벤션을 준수했나요?
- [x] 불필요한 주석이나 print문은 제거했나요?
- [ ] 로컬에서 테스트는 성공했나요?
