### PR TITLE
[REFACTOR] 서비스 계층의 유효성 검증 로직을 도메인 내부로 이동 (#76)

### DIFF
--- a/src/main/java/com/youthexpedition/azit/modules/crew/adapter/out/persistence/repository/CrewRepository.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/adapter/out/persistence/repository/CrewRepository.java
@@ -18,10 +18,14 @@ public interface CrewRepository extends JpaRepository<CrewEntity, Long> {
     void incrementMemberCount(@Param("crewId") Long crewId);
 
     @Modifying(clearAutomatically = true)
-    @Query("UPDATE CrewEntity c SET c.memberCount = c.memberCount - 1 WHERE c.id = :crewId")
+    @Query(value = "UPDATE crew SET member_count = member_count - 1, " +
+            "status = CASE WHEN member_count - 1 = 0 THEN 'INACTIVE' ELSE status END " +
+            "WHERE id = :crewId AND member_count > 0", nativeQuery = true)
     void decrementMemberCount(@Param("crewId") Long crewId);
 
     @Modifying(clearAutomatically = true)
-    @Query("UPDATE CrewEntity c SET c.memberCount = c.memberCount - 1 WHERE c.id IN :crewIds")
+    @Query(value = "UPDATE crew SET member_count = member_count - 1, " +
+            "status = CASE WHEN member_count - 1 = 0 THEN 'INACTIVE' ELSE status END " +
+            "WHERE id IN :crewIds AND member_count > 0", nativeQuery = true)
     void decrementMemberCountBatch(@Param("crewIds") List<Long> crewIds);
 }

--- a/src/main/java/com/youthexpedition/azit/modules/crew/adapter/out/persistence/repository/CrewRepository.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/adapter/out/persistence/repository/CrewRepository.java
@@ -17,13 +17,13 @@ public interface CrewRepository extends JpaRepository<CrewEntity, Long> {
     @Query("UPDATE CrewEntity c SET c.memberCount = c.memberCount + 1 WHERE c.id = :crewId")
     void incrementMemberCount(@Param("crewId") Long crewId);
 
-    @Modifying(clearAutomatically = true)
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query(value = "UPDATE crew SET member_count = member_count - 1, " +
             "status = CASE WHEN member_count - 1 = 0 THEN 'INACTIVE' ELSE status END " +
             "WHERE id = :crewId AND member_count > 0", nativeQuery = true)
     void decrementMemberCount(@Param("crewId") Long crewId);
 
-    @Modifying(clearAutomatically = true)
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query(value = "UPDATE crew SET member_count = member_count - 1, " +
             "status = CASE WHEN member_count - 1 = 0 THEN 'INACTIVE' ELSE status END " +
             "WHERE id IN :crewIds AND member_count > 0", nativeQuery = true)

--- a/src/main/java/com/youthexpedition/azit/modules/crew/application/service/CrewScheduleService.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/application/service/CrewScheduleService.java
@@ -109,9 +109,7 @@ public class CrewScheduleService implements CrewScheduleUseCase {
         validateCreator(schedule, command.creatorId());
 
         // 출석이 가능한 시간인 경우 수정 및 삭제 불가
-        if (!schedule.isModifiable(LocalDateTime.now())) {
-            throw new BusinessException(CrewErrorCode.SCHEDULE_MODIFICATION_NOT_ALLOWED_TIME);
-        }
+        schedule.validateModifiable(LocalDateTime.now());
 
         // 크루 정회원인지 확인
         CrewMember creator = getJoinedMember(command.crewId(), command.creatorId());
@@ -147,17 +145,13 @@ public class CrewScheduleService implements CrewScheduleUseCase {
         CrewSchedule schedule = getSchedule(command.scheduleId());
 
         // 이미 취소된 일정인지 확인
-        if (schedule.isCancelled()) {
-            throw new BusinessException(CrewErrorCode.ALREADY_CANCELLED_SCHEDULE);
-        }
+        schedule.validateNotCancelled();
 
         // 본인이 생성한 일정인지 확인
         validateCreator(schedule, command.creatorId());
 
         // 출석이 가능한 시간인 경우 수정 및 삭제 불가
-        if (!schedule.isModifiable(LocalDateTime.now())) {
-            throw new BusinessException(CrewErrorCode.SCHEDULE_MODIFICATION_NOT_ALLOWED_TIME);
-        }
+        schedule.validateModifiable(LocalDateTime.now());
 
         // 크루 정회원인지 확인
         getJoinedMember(command.crewId(), command.creatorId());
@@ -177,18 +171,10 @@ public class CrewScheduleService implements CrewScheduleUseCase {
         getJoinedMember(command.crewId(), command.memberId());
 
         // 일정 참여 가능한지 검증
-        if (schedule.isCancelled()) {
-            throw new BusinessException(CrewErrorCode.ALREADY_CANCELLED_SCHEDULE);
-        }
-        if (schedule.isParticipating(command.memberId())) {
-            throw new BusinessException(CrewErrorCode.ALREADY_PARTICIPATED);
-        }
-        if (schedule.isFull()) {
-            throw new BusinessException(CrewErrorCode.EXCEEDED_MAX_PARTICIPANTS);
-        }
-        if (!schedule.isParticipationModifiable(LocalDateTime.now())) {
-            throw new BusinessException(CrewErrorCode.PARTICIPATION_AND_CANCEL_CLOSED);
-        }
+        schedule.validateNotCancelled();
+        schedule.validateNotParticipating(command.memberId());
+        schedule.validateNotFull();
+        schedule.validateParticipationModifiable(LocalDateTime.now());
 
         // 기존 일정과의 시간 간격 검증
         validateScheduleInterval(command.memberId(), schedule.getMeetingAt());
@@ -203,9 +189,7 @@ public class CrewScheduleService implements CrewScheduleUseCase {
         CrewSchedule schedule = getSchedule(command.scheduleId());
 
         // 참여 중인지 확인
-        if (!schedule.isParticipating(command.memberId())) {
-            throw new BusinessException(CrewErrorCode.NOT_PARTICIPATING_SCHEDULE);
-        }
+        schedule.validateParticipating(command.memberId());
         // 본인이 일정 생성자인지 확인
         if (schedule.getCreatorId().equals(command.memberId())) {
             throw new BusinessException(CrewErrorCode.CREATOR_CANNOT_CANCEL_PARTICIPATION);
@@ -213,9 +197,7 @@ public class CrewScheduleService implements CrewScheduleUseCase {
         if (schedule.isCheckedIn(command.memberId())) {
             throw new BusinessException(CrewErrorCode.CANNOT_CANCEL_AFTER_CHECK_IN);
         }
-        if (!schedule.isParticipationModifiable(LocalDateTime.now())) {
-            throw new BusinessException(CrewErrorCode.PARTICIPATION_AND_CANCEL_CLOSED);
-        }
+        schedule.validateParticipationModifiable(LocalDateTime.now());
 
         // 크루 정회원인지 확인
         getJoinedMember(command.crewId(), command.memberId());
@@ -247,9 +229,7 @@ public class CrewScheduleService implements CrewScheduleUseCase {
         CrewSchedule schedule = getSchedule(command.scheduleId());
 
         // 취소된 일정인지 확인
-        if (schedule.isCancelled()) {
-            throw new BusinessException(CrewErrorCode.ALREADY_CANCELLED_SCHEDULE);
-        }
+        schedule.validateNotCancelled();
 
         // 크루 정회원인지 확인
         getJoinedMember(command.crewId(), command.memberId());
@@ -424,9 +404,7 @@ public class CrewScheduleService implements CrewScheduleUseCase {
         }
 
         // 출석 처리
-        if (!schedule.isParticipating(command.memberId())) {
-            throw new BusinessException(CrewErrorCode.NOT_PARTICIPATING_SCHEDULE);
-        }
+        schedule.validateParticipating(command.memberId());
         schedule.checkIn(command.memberId(), now);
         member.updateAttendanceCount();
 
@@ -532,8 +510,7 @@ public class CrewScheduleService implements CrewScheduleUseCase {
 
     // 생성할 일정 유효성 체크
     private void validateSchedule(CrewSchedule schedule) {
-        // 현재보다 이후의 시간인지 검증
-        if (!schedule.isMeetingTimeValid()) throw new BusinessException(CrewErrorCode.INVALID_SCHEDULE_TIME);
+        schedule.validateMeetingTime();
     }
 
     // 신청하려는 일정과 기존 일정 사이의 간격 검증, 신청하기/일정 생성 시 사용

--- a/src/main/java/com/youthexpedition/azit/modules/crew/application/service/CrewScheduleService.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/application/service/CrewScheduleService.java
@@ -510,7 +510,7 @@ public class CrewScheduleService implements CrewScheduleUseCase {
 
     // 생성할 일정 유효성 체크
     private void validateSchedule(CrewSchedule schedule) {
-        schedule.validateMeetingTime();
+        schedule.validateMeetingTime(LocalDateTime.now());
     }
 
     // 신청하려는 일정과 기존 일정 사이의 간격 검증, 신청하기/일정 생성 시 사용

--- a/src/main/java/com/youthexpedition/azit/modules/crew/application/service/CrewService.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/application/service/CrewService.java
@@ -126,20 +126,8 @@ public class CrewService implements CrewUseCase {
                                 throw new BusinessException(CrewErrorCode.ALREADY_JOINED_CREW);
                             }
 
-                            // 방출 후 24시간 이내 재가입 차단
-                            if (existingMember.getStatus() == CrewMemberStatus.EXPELLED && existingMember.isRejoinCooldownActive(now)) {
-                                throw new BusinessException(CrewErrorCode.EXPELLED_REJOINING_COOLDOWN);
-                            }
-
-                            // 자진 탈퇴 후 24시간 이내 재가입 차단
-                            if (existingMember.getStatus() == CrewMemberStatus.EXITED && existingMember.isExitCooldownActive(now)) {
-                                throw new BusinessException(CrewErrorCode.EXIT_REJOINING_COOLDOWN);
-                            }
-
-                            // 가입 신청 취소 후 24시간 이내 재신청 차단
-                            if (existingMember.getStatus() == CrewMemberStatus.CANCELLED && existingMember.isCancelCooldownActive(now)) {
-                                throw new BusinessException(CrewErrorCode.CANCEL_REJOINING_COOLDOWN);
-                            }
+                            // 재가입 쿨다운 검증 (방출/탈퇴/취소 후 일정 시간 이내 재가입 차단)
+                            existingMember.validateRejoinEligibility(now);
 
                             // 탈퇴, 방출(쿨다운 지남), 거절 상태일 경우 재신청
                             existingMember.reJoin();

--- a/src/main/java/com/youthexpedition/azit/modules/crew/domain/model/CrewMember.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/domain/model/CrewMember.java
@@ -1,5 +1,7 @@
 package com.youthexpedition.azit.modules.crew.domain.model;
 
+import com.youthexpedition.azit.infrastructure.exception.BusinessException;
+import com.youthexpedition.azit.modules.crew.domain.model.enums.CrewErrorCode;
 import com.youthexpedition.azit.modules.crew.domain.model.enums.CrewMemberRole;
 import com.youthexpedition.azit.modules.crew.domain.model.enums.CrewMemberStatus;
 import lombok.AllArgsConstructor;
@@ -95,6 +97,19 @@ public class CrewMember {
     public boolean isCancelCooldownActive(LocalDateTime now) {
         if (this.cancelledAt == null) return false;
         return this.cancelledAt.plusHours(CANCEL_COOLDOWN_HOURS).isAfter(now);
+    }
+
+    // 재가입 쿨다운 통합 검증
+    public void validateRejoinEligibility(LocalDateTime now) {
+        if (this.status == CrewMemberStatus.EXPELLED && isRejoinCooldownActive(now)) {
+            throw new BusinessException(CrewErrorCode.EXPELLED_REJOINING_COOLDOWN);
+        }
+        if (this.status == CrewMemberStatus.EXITED && isExitCooldownActive(now)) {
+            throw new BusinessException(CrewErrorCode.EXIT_REJOINING_COOLDOWN);
+        }
+        if (this.status == CrewMemberStatus.CANCELLED && isCancelCooldownActive(now)) {
+            throw new BusinessException(CrewErrorCode.CANCEL_REJOINING_COOLDOWN);
+        }
     }
 
     // 가입 재신청

--- a/src/main/java/com/youthexpedition/azit/modules/crew/domain/model/CrewSchedule.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/domain/model/CrewSchedule.java
@@ -61,13 +61,13 @@ public class CrewSchedule {
         return schedule;
     }
 
-    // 현재보다 과거 시간인지 검증
-    public boolean isMeetingTimeValid() {
-        return this.meetingAt != null && this.meetingAt.isAfter(LocalDateTime.now());
+    // 현재보다 미래 시간인지 검증
+    public boolean isMeetingTimeValid(LocalDateTime now) {
+        return this.meetingAt != null && this.meetingAt.isAfter(now);
     }
 
-    public void validateMeetingTime() {
-        if (!isMeetingTimeValid()) throw new BusinessException(CrewErrorCode.INVALID_SCHEDULE_TIME);
+    public void validateMeetingTime(LocalDateTime now) {
+        if (!isMeetingTimeValid(now)) throw new BusinessException(CrewErrorCode.INVALID_SCHEDULE_TIME);
     }
 
     // 일정 수정

--- a/src/main/java/com/youthexpedition/azit/modules/crew/domain/model/CrewSchedule.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/domain/model/CrewSchedule.java
@@ -1,5 +1,7 @@
 package com.youthexpedition.azit.modules.crew.domain.model;
 
+import com.youthexpedition.azit.infrastructure.exception.BusinessException;
+import com.youthexpedition.azit.modules.crew.domain.model.enums.CrewErrorCode;
 import com.youthexpedition.azit.modules.crew.domain.model.enums.RunType;
 import com.youthexpedition.azit.modules.crew.domain.model.enums.ScheduleStatus;
 import lombok.AllArgsConstructor;
@@ -64,6 +66,10 @@ public class CrewSchedule {
         return this.meetingAt != null && this.meetingAt.isAfter(LocalDateTime.now());
     }
 
+    public void validateMeetingTime() {
+        if (!isMeetingTimeValid()) throw new BusinessException(CrewErrorCode.INVALID_SCHEDULE_TIME);
+    }
+
     // 일정 수정
     public void update(
             String title, RunType runType, LocalDateTime meetingAt, Location location,
@@ -89,9 +95,17 @@ public class CrewSchedule {
         return this.status == ScheduleStatus.CANCELLED;
     }
 
+    public void validateNotCancelled() {
+        if (isCancelled()) throw new BusinessException(CrewErrorCode.ALREADY_CANCELLED_SCHEDULE);
+    }
+
     // 최대 인원 확인
     public boolean isFull() {
         return participants.size() >= maxParticipants;
+    }
+
+    public void validateNotFull() {
+        if (isFull()) throw new BusinessException(CrewErrorCode.EXCEEDED_MAX_PARTICIPANTS);
     }
 
     // 일정 수정 및 삭제 가능한지 확인 (출석 시작 후 불가)
@@ -99,14 +113,30 @@ public class CrewSchedule {
         return currentTime.isBefore(this.meetingAt.minusHours(ACTIVE_CHECK_IN_WINDOW_HOURS));
     }
 
+    public void validateModifiable(LocalDateTime currentTime) {
+        if (!isModifiable(currentTime)) throw new BusinessException(CrewErrorCode.SCHEDULE_MODIFICATION_NOT_ALLOWED_TIME);
+    }
+
     // 일정 참여 및 참여 취소 가능한 시간인지 확인
     public boolean isParticipationModifiable(LocalDateTime currentTime) {
         return currentTime.isBefore(this.meetingAt.plusHours(ACTIVE_CHECK_IN_WINDOW_HOURS));
     }
 
+    public void validateParticipationModifiable(LocalDateTime currentTime) {
+        if (!isParticipationModifiable(currentTime)) throw new BusinessException(CrewErrorCode.PARTICIPATION_AND_CANCEL_CLOSED);
+    }
+
     // 일정에 참여하고 있는지 확인
     public boolean isParticipating(Long memberId) {
         return participants.containsKey(memberId);
+    }
+
+    public void validateParticipating(Long memberId) {
+        if (!isParticipating(memberId)) throw new BusinessException(CrewErrorCode.NOT_PARTICIPATING_SCHEDULE);
+    }
+
+    public void validateNotParticipating(Long memberId) {
+        if (isParticipating(memberId)) throw new BusinessException(CrewErrorCode.ALREADY_PARTICIPATED);
     }
 
     // 일정 참여

--- a/src/main/java/com/youthexpedition/azit/modules/member/application/service/DeliveryAddressService.java
+++ b/src/main/java/com/youthexpedition/azit/modules/member/application/service/DeliveryAddressService.java
@@ -70,9 +70,7 @@ public class DeliveryAddressService implements DeliveryAddressUseCase {
         DeliveryAddress deliveryAddress = getAddressValidated(addressId, memberId);
 
         // 삭제 가능한지 확인 (기본 배송지는 삭제 불가)
-        if (!deliveryAddress.isDeletable()) {
-            throw new BusinessException(DeliveryAddressErrorCode.CANNOT_DELETE_DEFAULT_ADDRESS);
-        }
+        deliveryAddress.validateDeletable();
 
         saveDeliveryAddressPort.delete(deliveryAddress);
     }

--- a/src/main/java/com/youthexpedition/azit/modules/member/application/service/MemberService.java
+++ b/src/main/java/com/youthexpedition/azit/modules/member/application/service/MemberService.java
@@ -126,9 +126,7 @@ public class MemberService implements MemberUseCase {
         processCrewWithdrawal(memberId);
 
         // 이미 탈퇴한 회원이 아닌 경우에만 상태 변경
-        if (member.isWithdrawn()) {
-            throw new BusinessException(MemberErrorCode.MEMBER_ALREADY_WITHDRAWN);
-        }
+        member.validateNotWithdrawn();
         member.withdraw();
 
         tokenPort.deleteByMemberId(memberId); // 리프레시 토큰 삭제
@@ -149,9 +147,7 @@ public class MemberService implements MemberUseCase {
         processCrewWithdrawal(member.getId());
 
         // 이미 탈퇴한 회원이 아닌 경우에만 상태 변경
-        if (member.isWithdrawn()) {
-            throw new BusinessException(MemberErrorCode.MEMBER_ALREADY_WITHDRAWN);
-        }
+        member.validateNotWithdrawn();
         member.withdraw();
 
         tokenPort.deleteByMemberId(member.getId()); // 리프레시 토큰 삭제

--- a/src/main/java/com/youthexpedition/azit/modules/member/domain/model/DeliveryAddress.java
+++ b/src/main/java/com/youthexpedition/azit/modules/member/domain/model/DeliveryAddress.java
@@ -75,4 +75,8 @@ public class DeliveryAddress {
     public boolean isDeletable() {
         return !this.isDefault;
     }
+
+    public void validateDeletable() {
+        if (!isDeletable()) throw new BusinessException(DeliveryAddressErrorCode.CANNOT_DELETE_DEFAULT_ADDRESS);
+    }
 }

--- a/src/main/java/com/youthexpedition/azit/modules/member/domain/model/Member.java
+++ b/src/main/java/com/youthexpedition/azit/modules/member/domain/model/Member.java
@@ -1,5 +1,7 @@
 package com.youthexpedition.azit.modules.member.domain.model;
 
+import com.youthexpedition.azit.infrastructure.exception.BusinessException;
+import com.youthexpedition.azit.modules.member.domain.model.enums.MemberErrorCode;
 import com.youthexpedition.azit.modules.member.domain.model.enums.MemberRole;
 import com.youthexpedition.azit.modules.member.domain.model.enums.MemberStatus;
 import com.youthexpedition.azit.modules.member.domain.model.enums.SocialProvider;
@@ -80,6 +82,10 @@ public class Member {
         return this.status == MemberStatus.WITHDRAWN;
     }
 
+    public void validateNotWithdrawn() {
+        if (isWithdrawn()) throw new BusinessException(MemberErrorCode.MEMBER_ALREADY_WITHDRAWN);
+    }
+
     // 탈퇴 상태로 변경
     public void withdraw() {
         this.status = MemberStatus.WITHDRAWN;
@@ -97,6 +103,10 @@ public class Member {
     // 포인트가 충분한지 체크
     public boolean hasEnoughPoints(long points) {
         return this.totalPoints >= points;
+    }
+
+    public void validateEnoughPoints(long points) {
+        if (!hasEnoughPoints(points)) throw new BusinessException(MemberErrorCode.INSUFFICIENT_POINTS);
     }
 
     // 포인트 차감

--- a/src/main/java/com/youthexpedition/azit/modules/store/application/service/OrderService.java
+++ b/src/main/java/com/youthexpedition/azit/modules/store/application/service/OrderService.java
@@ -186,9 +186,7 @@ public class OrderService implements OrderUseCase {
         Order savedOrder = saveOrderPort.save(order);
 
         // 포인트 검증
-        if (!member.hasEnoughPoints(command.usedPoints())) {
-            throw new BusinessException(MemberErrorCode.INSUFFICIENT_POINTS);
-        }
+        member.validateEnoughPoints(command.usedPoints());
         // 포인트 차감
         member.deductPoints(command.usedPoints());
         saveMemberPort.save(member);
@@ -242,9 +240,7 @@ public class OrderService implements OrderUseCase {
         }
 
         // 주문 취소 가능한 상태인지 확인
-        if (!order.isCancellable()) {
-            throw new BusinessException(StoreErrorCode.CANNOT_CANCEL_ORDER);
-        }
+        order.validateCancellable();
         // 주문 취소 상태로 변경
         order.cancel();
 

--- a/src/main/java/com/youthexpedition/azit/modules/store/domain/model/Order.java
+++ b/src/main/java/com/youthexpedition/azit/modules/store/domain/model/Order.java
@@ -1,7 +1,9 @@
 package com.youthexpedition.azit.modules.store.domain.model;
 
+import com.youthexpedition.azit.infrastructure.exception.BusinessException;
 import com.youthexpedition.azit.modules.store.domain.model.enums.OrderStatus;
 import com.youthexpedition.azit.modules.store.domain.model.enums.PaymentMethod;
+import com.youthexpedition.azit.modules.store.domain.model.enums.StoreErrorCode;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -70,6 +72,10 @@ public class Order {
     // 취소 가능한 상태인지 확인
     public boolean isCancellable() {
         return this.status == OrderStatus.PENDING || this.status == OrderStatus.PAID;
+    }
+
+    public void validateCancellable() {
+        if (!isCancellable()) throw new BusinessException(StoreErrorCode.CANNOT_CANCEL_ORDER);
     }
 
     // 주문 취소


### PR DESCRIPTION
## 📌 관련 이슈
- close #76

## ✨ 작업 내용

- **도메인 validate 메서드 추가**: boolean 반환 메서드(`isXxx()`)의 결과를 서비스에서 체크해 예외를 던지던 패턴을 도메인 내부의 `validateXxx()` 메서드로 캡슐화
- **CrewSchedule**: `validateMeetingTime`, `validateNotCancelled`, `validateNotFull`, `validateModifiable`, `validateParticipationModifiable`, `validateParticipating`, `validateNotParticipating` 추가
- **CrewMember**: `validateRejoinEligibility(LocalDateTime)` 추가 — 방출/탈퇴/취소 쿨다운 검증 로직 3개 if 블록 통합
- **Member**: `validateNotWithdrawn`, `validateEnoughPoints(long)` 추가
- **DeliveryAddress**: `validateDeletable` 추가
- **Order**: `validateCancellable` 추가
- **서비스 계층 정리**: `CrewScheduleService`, `CrewService`, `MemberService`, `DeliveryAddressService`, `OrderService`에서 `if (!domain.isXxx()) throw new BusinessException(...)` 패턴을 도메인 validate 호출로 교체
- **INACTIVE 처리**: 크루 멤버 수 감소 시 0명이 되면 native SQL CASE WHEN으로 상태를 INACTIVE로 변경

## ⚠️ 주의 사항 (선택)
- [ ] DB 스키마 변경이 있나요?
- [ ] API 명세(Swagger)가 업데이트 되었나요?
- [ ] 새로운 환경 변수(.env)가 추가 되었나요?

## ✅ 셀프 체크리스트
- [x] 브랜치 전략(develop)에 맞게 올렸나요?
- [x] 커밋 컨벤션을 준수했나요?
- [x] 불필요한 주석이나 print문은 제거했나요?
- [ ] 로컬에서 테스트는 성공했나요?