### PR TITLE
[FEAT] 크루 스케줄 캘린더 조회 API에 주간 단위 조회 파라미터 추가

### DIFF
--- a/src/main/java/com/youthexpedition/azit/modules/crew/adapter/in/web/CrewScheduleController.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/adapter/in/web/CrewScheduleController.java
@@ -107,8 +107,12 @@ public class CrewScheduleController implements CrewScheduleControllerDocs {
 
     @GetMapping("/calendar")
     public CommonResponse<List<CrewScheduleMonthlyListResponse>> getMonthlySchedulesForCalendar(
-            @PathVariable Long crewId, @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM") YearMonth yearMonth, @CurrentMemberId Long memberId) {
-        CrewScheduleMonthlyQuery query = CrewScheduleMonthlyQuery.of(crewId, yearMonth, memberId);
+            @PathVariable Long crewId,
+            @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate startDate,
+            @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate endDate,
+            @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM") YearMonth yearMonth,
+            @CurrentMemberId Long memberId) {
+        CrewScheduleMonthlyQuery query = CrewScheduleMonthlyQuery.of(crewId, startDate, endDate, yearMonth, memberId);
         List<CrewScheduleMonthlyListResponse> response = crewScheduleUseCase.getMonthlySchedulesForCalendar(query);
 
         return CommonResponse.of(CommonSuccessCode.SUCCESS, response);

--- a/src/main/java/com/youthexpedition/azit/modules/crew/adapter/in/web/docs/CrewScheduleControllerDocs.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/adapter/in/web/docs/CrewScheduleControllerDocs.java
@@ -184,7 +184,7 @@ public interface CrewScheduleControllerDocs {
 
             **[쿼리 파라미터]** <br>
             * date (선택): 특정 날짜(yyyy-MM-dd)의 일정만 조회합니다. 다른 파라미터보다 우선 적용됩니다.
-            * startDate / endDate (선택): 조회할 날짜 범위(yyyy-MM-dd)입니다. 두 값이 모두 있어야 동작하며, 주 단위 조회에 활용합니다.
+            * startDate / endDate (선택): 조회할 날짜 범위(yyyy-MM-dd)입니다. 두 값이 모두 있어야 동작합니다.
             * yearMonth (선택): 조회할 연월(yyyy-MM)입니다. 미입력 시 현재 월을 기준으로 조회합니다.
             * runType (선택): REGULAR 또는 LIGHTNING으로 필터링합니다. 미입력 시 모든 타입을 조회합니다. <br><br>
 
@@ -210,25 +210,31 @@ public interface CrewScheduleControllerDocs {
             @Parameter(hidden = true) @CurrentMemberId Long memberId);
 
     @Operation(
-            summary = "월간 크루 일정 목록 조회 (캘린더 표시용)",
+            summary = "월간/주간 크루 일정 목록 조회 (캘린더 표시용)",
             description = """
-            특정 월의 날짜별 일정 존재 여부(정기런/번개런)를 조회합니다. 일정이 하나라도 존재하는 날짜만 조회됩니다. <br>
+            날짜별 일정 존재 여부(정기런/번개런)를 조회합니다. 일정이 하나라도 존재하는 날짜만 조회됩니다. <br>
             캘린더에서 각 날짜 하단에 상태 점을 표시하는 데 사용됩니다. <br><br>
-            
+
             **[쿼리 파라미터]** <br>
-            * yearMonth (선택): 조회할 연월(yyyy-MM)입니다. 미입력 시 현재 시간 기준의 월을 조회합니다.<br>
-            
+            * startDate / endDate (선택): 조회할 날짜 범위(yyyy-MM-dd)입니다. 두 값이 모두 있어야 동작합니다.<br>
+            * yearMonth (선택): 조회할 연월(yyyy-MM)입니다. 미입력 시 현재 월을 기준으로 조회합니다. <br><br>
+
+            **[파라미터 우선순위]** <br>
+            startDate·endDate > yearMonth > 현재 월 <br><br>
+
             **[참고 사항]** <br>
             * 해당 크루의 정회원(JOINED)만 조회가 가능합니다. (NOT_A_CREW_MEMBER)
             * 취소(삭제)된 일정은 응답에서 제외됩니다.
             """
     )
     @ApiErrorCodeExamples({
-            "NOT_A_CREW_MEMBER",
+            "NOT_A_CREW_MEMBER", "INVALID_DATE_RANGE",
             "UNAUTHORIZED", "EXPIRED_TOKEN", "INVALID_TOKEN", "TOKEN_REUSE_DETECTED", "BLACKLISTED_TOKEN"
     })
     CommonResponse<List<CrewScheduleMonthlyListResponse>> getMonthlySchedulesForCalendar(
             @PathVariable Long crewId,
+            @Parameter(description = "조회 시작 날짜 (yyyy-MM-dd), endDate와 함께 사용") LocalDate startDate,
+            @Parameter(description = "조회 종료 날짜 (yyyy-MM-dd), startDate와 함께 사용") LocalDate endDate,
             @Parameter(description = "조회 연월 (yyyy-MM)") YearMonth yearMonth,
             @Parameter(hidden = true) @CurrentMemberId Long memberId);
 }

--- a/src/main/java/com/youthexpedition/azit/modules/crew/adapter/out/persistence/CrewSchedulePersistenceAdapter.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/adapter/out/persistence/CrewSchedulePersistenceAdapter.java
@@ -50,8 +50,8 @@ public class CrewSchedulePersistenceAdapter implements LoadCrewSchedulePort, Sav
     }
 
     @Override
-    public Map<LocalDate, Set<RunType>> findMonthlySchedulesForCalendar(Long crewId, YearMonth yearMonth) {
-        return crewScheduleRepository.findMonthlySchedulesForCalendar(crewId, yearMonth);
+    public Map<LocalDate, Set<RunType>> findMonthlySchedulesForCalendar(Long crewId, LocalDate startDate, LocalDate endDate, YearMonth yearMonth) {
+        return crewScheduleRepository.findMonthlySchedulesForCalendar(crewId, startDate, endDate, yearMonth);
     }
 
     @Override

--- a/src/main/java/com/youthexpedition/azit/modules/crew/adapter/out/persistence/repository/CrewScheduleRepositoryCustom.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/adapter/out/persistence/repository/CrewScheduleRepositoryCustom.java
@@ -13,7 +13,7 @@ import java.util.Set;
 
 public interface CrewScheduleRepositoryCustom {
     List<CrewScheduleEntity> findAllByFilter(Long crewId, LocalDate date, LocalDate startDate, LocalDate endDate, YearMonth yearMonth, RunType runType);
-    Map<LocalDate, Set<RunType>> findMonthlySchedulesForCalendar(Long crewId, YearMonth yearMonth);
+    Map<LocalDate, Set<RunType>> findMonthlySchedulesForCalendar(Long crewId, LocalDate startDate, LocalDate endDate, YearMonth yearMonth);
     List<CrewScheduleEntity> findAllByMemberId(Long memberId);
     List<CrewScheduleEntity> findAllTodaySchedulesByMemberId(Long memberId, LocalDateTime now);
     Optional<CrewScheduleEntity> findNextClosestScheduleByMemberId(Long memberId, LocalDateTime now);

--- a/src/main/java/com/youthexpedition/azit/modules/crew/adapter/out/persistence/repository/CrewScheduleRepositoryImpl.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/adapter/out/persistence/repository/CrewScheduleRepositoryImpl.java
@@ -40,19 +40,14 @@ public class CrewScheduleRepositoryImpl implements CrewScheduleRepositoryCustom 
     }
 
     @Override
-    public Map<LocalDate, Set<RunType>> findMonthlySchedulesForCalendar(Long crewId, YearMonth yearMonth) {
-        // 해당 월의 검색 범위 계산
-        LocalDateTime start = yearMonth.atDay(1).atStartOfDay();
-        LocalDateTime end = yearMonth.atEndOfMonth().atTime(LocalTime.MAX);
-
-        // 특정 컬럼만 가져오므로 tuple 사용
+    public Map<LocalDate, Set<RunType>> findMonthlySchedulesForCalendar(Long crewId, LocalDate startDate, LocalDate endDate, YearMonth yearMonth) {
         List<Tuple> results = queryFactory
                 .select(crewScheduleEntity.meetingAt, crewScheduleEntity.runType)
                 .from(crewScheduleEntity)
                 .where(
                         crewScheduleEntity.crewId.eq(crewId),
                         crewScheduleEntity.status.eq(ScheduleStatus.ACTIVE),
-                        crewScheduleEntity.meetingAt.between(start, end)
+                        filterByDateRange(null, startDate, endDate, yearMonth)
                 )
                 .fetch();
 

--- a/src/main/java/com/youthexpedition/azit/modules/crew/application/port/in/query/CrewScheduleMonthlyQuery.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/application/port/in/query/CrewScheduleMonthlyQuery.java
@@ -1,17 +1,16 @@
 package com.youthexpedition.azit.modules.crew.application.port.in.query;
 
+import java.time.LocalDate;
 import java.time.YearMonth;
 
 public record CrewScheduleMonthlyQuery(
         Long crewId,
         YearMonth yearMonth,
+        LocalDate startDate,
+        LocalDate endDate,
         Long memberId
 ) {
-    public static CrewScheduleMonthlyQuery of(Long crewId, YearMonth yearMonth, Long memberId) {
-        return new CrewScheduleMonthlyQuery(
-                crewId,
-                yearMonth != null ? yearMonth : YearMonth.now(),
-                memberId
-        );
+    public static CrewScheduleMonthlyQuery of(Long crewId, LocalDate startDate, LocalDate endDate, YearMonth yearMonth, Long memberId) {
+        return new CrewScheduleMonthlyQuery(crewId, yearMonth, startDate, endDate, memberId);
     }
 }

--- a/src/main/java/com/youthexpedition/azit/modules/crew/application/port/in/query/CrewScheduleMonthlyQuery.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/application/port/in/query/CrewScheduleMonthlyQuery.java
@@ -5,12 +5,12 @@ import java.time.YearMonth;
 
 public record CrewScheduleMonthlyQuery(
         Long crewId,
-        YearMonth yearMonth,
         LocalDate startDate,
         LocalDate endDate,
+        YearMonth yearMonth,
         Long memberId
 ) {
     public static CrewScheduleMonthlyQuery of(Long crewId, LocalDate startDate, LocalDate endDate, YearMonth yearMonth, Long memberId) {
-        return new CrewScheduleMonthlyQuery(crewId, yearMonth, startDate, endDate, memberId);
+        return new CrewScheduleMonthlyQuery(crewId, startDate, endDate, yearMonth, memberId);
     }
 }

--- a/src/main/java/com/youthexpedition/azit/modules/crew/application/port/out/LoadCrewSchedulePort.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/application/port/out/LoadCrewSchedulePort.java
@@ -14,7 +14,7 @@ import java.util.Set;
 public interface LoadCrewSchedulePort {
     Optional<CrewSchedule> findById(Long scheduleId);
     List<CrewSchedule> findAllByFilter(Long crewId, LocalDate date, LocalDate startDate, LocalDate endDate, YearMonth yearMonth, RunType runType);
-    Map<LocalDate, Set<RunType>> findMonthlySchedulesForCalendar(Long crewId, YearMonth yearMonth);
+    Map<LocalDate, Set<RunType>> findMonthlySchedulesForCalendar(Long crewId, LocalDate startDate, LocalDate endDate, YearMonth yearMonth);
     List<CrewSchedule> findAllByMemberId(Long memberId);
     List<CrewSchedule> findAllTodaySchedulesByMemberId(Long memberId, LocalDateTime now);
     Optional<CrewSchedule> findNextClosestScheduleByMemberId(Long memberId, LocalDateTime now);

--- a/src/main/java/com/youthexpedition/azit/modules/crew/application/service/CrewScheduleService.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/application/service/CrewScheduleService.java
@@ -273,8 +273,9 @@ public class CrewScheduleService implements CrewScheduleUseCase {
     public List<CrewScheduleMonthlyListResponse> getMonthlySchedulesForCalendar(CrewScheduleMonthlyQuery query) {
         // 정회원인지 확인
         getJoinedMember(query.crewId(), query.memberId());
+        validateDateRange(query.startDate(), query.endDate());
 
-        Map<LocalDate, Set<RunType>> monthlyScheduleMap = loadCrewSchedulePort.findMonthlySchedulesForCalendar(query.crewId(), query.yearMonth());
+        Map<LocalDate, Set<RunType>> monthlyScheduleMap = loadCrewSchedulePort.findMonthlySchedulesForCalendar(query.crewId(), query.startDate(), query.endDate(), query.yearMonth());
 
         return crewScheduleResponseMapper.toScheduleMonthlyListResponse(monthlyScheduleMap);
     }


### PR DESCRIPTION
## 📌 관련 이슈
- 해당 없음

## ✨ 작업 내용
> 캘린더 일정 조회 API에 주간 단위 조회를 지원하기 위해 `startDate` / `endDate` 파라미터를 추가했습니다.

- `GET /api/v1/crews/{crewId}/schedules/calendar` 엔드포인트에 `startDate`, `endDate` 쿼리 파라미터 추가
- 파라미터 우선순위: `startDate·endDate` > `yearMonth` > 현재 월 (기존 동작 유지)
- 날짜 범위 유효성 검증(`validateDateRange`)을 서비스 레이어에서 재사용
- 날짜 범위 계산 로직을 서비스에서 제거하고, QueryDSL의 기존 `filterByDateRange` 메서드로 위임

## 🧱 아키텍처 변경 요약

- `CrewScheduleMonthlyQuery`: `startDate`, `endDate` 필드 추가 / `of()` 팩토리 메서드 시그니처 변경
- `LoadCrewSchedulePort` → `CrewSchedulePersistenceAdapter` → `CrewScheduleRepositoryCustom` → `CrewScheduleRepositoryImpl`: `findMonthlySchedulesForCalendar` 시그니처에 `startDate`, `endDate`, `yearMonth` 파라미터 추가
- `CrewScheduleRepositoryImpl`: 기존 `filterByDateRange` 재사용으로 날짜 범위 처리 일원화

## 📸 스크린샷 (선택 사항)

## ⚠️ 주의 사항 (선택)
- [ ] DB 스키마 변경이 있나요?
- [x] API 명세(Swagger)가 업데이트 되었나요?
- [ ] 새로운 환경 변수(.env)가 추가 되었나요?

## ✅ 셀프 체크리스트
- [ ] 브랜치 전략(develop)에 맞게 올렸나요?
- [ ] 커밋 컨벤션을 준수했나요?
- [ ] 불필요한 주석이나 print문은 제거했나요?
- [ ] 로컬에서 테스트는 성공했나요?