### PR TITLE
[FIX] 크루 가입 승인 시 crew_member 상태 미반영 버그 수정

### DIFF
--- a/src/main/java/com/youthexpedition/azit/modules/crew/adapter/out/persistence/repository/CrewRepository.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/adapter/out/persistence/repository/CrewRepository.java
@@ -13,7 +13,7 @@ public interface CrewRepository extends JpaRepository<CrewEntity, Long> {
     Optional<CrewEntity> findByInvitationCode(String invitationCode);
     boolean existsByInvitationCode(String invitationCode);
 
-    @Modifying(clearAutomatically = true)
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("UPDATE CrewEntity c SET c.memberCount = c.memberCount + 1 WHERE c.id = :crewId")
     void incrementMemberCount(@Param("crewId") Long crewId);
 


### PR DESCRIPTION
## 📌 관련 이슈
- 해당 없음

## ✨ 작업 내용
> 크루 가입 승인 API 호출 시 `crew_member` 테이블의 `status`가 `REQUESTED → JOINED`로 변경되지 않는 버그를 수정했습니다.

- `CrewRepository.incrementMemberCount`에 `flushAutomatically = true` 추가

**원인**
1. `saveCrewMemberPort.save()` → `em.merge()` → 영속성 컨텍스트에 `status=JOINED` 변경 예약 (아직 DB에 미반영)
2. `incrementMemberCount()` JPQL UPDATE 실행
3. `@Modifying(clearAutomatically = true)`에 의해 영속성 컨텍스트 초기화 → 1번에서 예약된 `crew_member` UPDATE가 flush 전에 소멸
4. 트랜잭션 커밋 → `member_count`만 반영, `status` 변경 누락

`flushAutomatically = true`를 추가하면 JPQL UPDATE 실행 전 영속성 컨텍스트를 먼저 flush하여 `crew_member` 상태 변경이 DB에 반영된 후 컨텍스트가 초기화됩니다.

## 🧱 아키텍처 변경 요약
- 해당 없음

## 📸 스크린샷 (선택 사항)

## ⚠️ 주의 사항 (선택)
- [ ] DB 스키마 변경이 있나요?
- [ ] API 명세(Swagger)가 업데이트 되었나요?
- [ ] 새로운 환경 변수(.env)가 추가 되었나요?

## ✅ 셀프 체크리스트
- [ ] 브랜치 전략(develop)에 맞게 올렸나요?
- [ ] 커밋 컨벤션을 준수했나요?
- [ ] 불필요한 주석이나 print문은 제거했나요?
- [ ] 로컬에서 테스트는 성공했나요?