### PR TITLE
[FEAT] 크루 이름 생성 시 한글, 영문, 숫자 외 문자 사용 제한

### DIFF
--- a/src/main/java/com/youthexpedition/azit/modules/crew/adapter/in/web/docs/CrewControllerDocs.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/adapter/in/web/docs/CrewControllerDocs.java
@@ -33,11 +33,12 @@ public interface CrewControllerDocs {
             
             **[제약 사항]** <br>
             * 크루 이름: 최대 15자 이내로 작성해야 합니다. (INVALID_INPUT_VALUE)
+            * 크루 이름: 한글, 영문, 숫자만 사용 가능합니다. (INVALID_CREW_NAME_CHARACTERS)
             * ACTIVE 상태의 사용자만 요청 가능합니다. (INVALID_MEMBER_STATUS)
             """
     )
     @ApiErrorCodeExamples({
-            "RESERVED_CREW_NAME_KEYWORD", "CREW_JOIN_LIMIT_EXCEEDED", "INVITATION_CODE_GENERATION_FAILED",
+            "INVALID_CREW_NAME_CHARACTERS", "RESERVED_CREW_NAME_KEYWORD", "CREW_JOIN_LIMIT_EXCEEDED", "INVITATION_CODE_GENERATION_FAILED",
             "UNAUTHORIZED", "EXPIRED_TOKEN", "INVALID_TOKEN", "TOKEN_REUSE_DETECTED", "BLACKLISTED_TOKEN" // 인증 관련 에러
     })
     CommonResponse<CreateCrewResponse> createCrew(
@@ -261,12 +262,13 @@ public interface CrewControllerDocs {
                     **[이외 제약 사항]** <br>
                     * 리더만 수정할 수 있습니다. (NOT_CREW_LEADER) <br>
                     * 크루 이름은 필수이며 최대 15자까지 입력 가능합니다. <br>
+                    * 크루 이름: 한글, 영문, 숫자만 사용 가능합니다. (INVALID_CREW_NAME_CHARACTERS) <br>
                     * 크루 한줄 소개는 선택이며 최대 20자까지 입력 가능합니다. (미입력 시 null로 저장)
                     """
     )
     @ApiErrorCodeExamples({
             "CREW_NOT_FOUND", "NOT_A_CREW_MEMBER", "NOT_CREW_LEADER",
-            "IMAGE_NOT_UPLOADED", "IMAGE_OWNERSHIP_MISMATCH", "RESERVED_CREW_NAME_KEYWORD",
+            "IMAGE_NOT_UPLOADED", "IMAGE_OWNERSHIP_MISMATCH", "INVALID_CREW_NAME_CHARACTERS", "RESERVED_CREW_NAME_KEYWORD",
             "UNAUTHORIZED", "EXPIRED_TOKEN", "INVALID_TOKEN", "TOKEN_REUSE_DETECTED", "BLACKLISTED_TOKEN"
     })
     CommonResponse<Void> updateCrewProfile(

--- a/src/main/java/com/youthexpedition/azit/modules/crew/domain/model/Crew.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/domain/model/Crew.java
@@ -11,6 +11,7 @@ import lombok.Getter;
 import java.security.SecureRandom;
 import java.time.LocalDateTime;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 @Getter
 @Builder
@@ -28,6 +29,7 @@ public class Crew {
     private final LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 
+    private static final Pattern VALID_NAME_PATTERN = Pattern.compile("^[가-힣a-zA-Z0-9]+$");
     private static final String CHARACTERS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
     private static final int CODE_LENGTH = 6;
     private static final SecureRandom RANDOM = new SecureRandom();
@@ -58,7 +60,7 @@ public class Crew {
 
     private static void validateName(String name) {
         // 크루 이름은 한글, 숫자, 영어만 가능 (특수문자 제한)
-        if (!name.matches("^[가-힣a-zA-Z0-9]+$")) {
+        if (!VALID_NAME_PATTERN.matcher(name).matches()) {
             throw new BusinessException(CrewErrorCode.INVALID_CREW_NAME_CHARACTERS);
         }
 

--- a/src/main/java/com/youthexpedition/azit/modules/crew/domain/model/Crew.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/domain/model/Crew.java
@@ -57,7 +57,13 @@ public class Crew {
     }
 
     private static void validateName(String name) {
+        // 크루 이름은 한글, 숫자, 영어만 가능 (특수문자 제한)
+        if (!name.matches("^[가-힣a-zA-Z0-9]+$")) {
+            throw new BusinessException(CrewErrorCode.INVALID_CREW_NAME_CHARACTERS);
+        }
+
         String lowerName = name.toLowerCase();
+        // 불가 예약어 검사
         boolean hasReservedKeyword = RESERVED_KEYWORDS.stream().anyMatch(lowerName::contains);
         if (hasReservedKeyword) {
             throw new BusinessException(CrewErrorCode.RESERVED_CREW_NAME_KEYWORD);

--- a/src/main/java/com/youthexpedition/azit/modules/crew/domain/model/enums/CrewErrorCode.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/domain/model/enums/CrewErrorCode.java
@@ -29,7 +29,7 @@ public enum CrewErrorCode implements BaseErrorCode {
     CREW_JOIN_LIMIT_EXCEEDED("CREW_JOIN_LIMIT_EXCEEDED", "최대 3개의 크루까지 가입할 수 있습니다.", HttpStatus.BAD_REQUEST),
     CREW_ALREADY_DISSOLVED("CREW_ALREADY_DISSOLVED", "이미 해산된 크루입니다.", HttpStatus.BAD_REQUEST),
     RESERVED_CREW_NAME_KEYWORD("RESERVED_CREW_NAME_KEYWORD", "사칭 방지를 위해 사용할 수 없는 단어가 포함되어 있습니다.", HttpStatus.BAD_REQUEST),
-    INVALID_CREW_NAME_CHARACTERS("INVALID_CREW_NAME_CHARACTERS", "크루 이름은 한글, 영문, 숫자만 사용할 수 있습니다.", HttpStatus.BAD_REQUEST),
+    INVALID_CREW_NAME_CHARACTERS("INVALID_CREW_NAME_CHARACTERS", "특수문자는 사용할 수 없어요.", HttpStatus.BAD_REQUEST),
 
     // 일정 관련
     INVALID_SCHEDULE_TIME("INVALID_SCHEDULE_TIME", "유효하지 않은 일정 시간입니다.", HttpStatus.BAD_REQUEST),

--- a/src/main/java/com/youthexpedition/azit/modules/crew/domain/model/enums/CrewErrorCode.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/domain/model/enums/CrewErrorCode.java
@@ -29,6 +29,7 @@ public enum CrewErrorCode implements BaseErrorCode {
     CREW_JOIN_LIMIT_EXCEEDED("CREW_JOIN_LIMIT_EXCEEDED", "최대 3개의 크루까지 가입할 수 있습니다.", HttpStatus.BAD_REQUEST),
     CREW_ALREADY_DISSOLVED("CREW_ALREADY_DISSOLVED", "이미 해산된 크루입니다.", HttpStatus.BAD_REQUEST),
     RESERVED_CREW_NAME_KEYWORD("RESERVED_CREW_NAME_KEYWORD", "사칭 방지를 위해 사용할 수 없는 단어가 포함되어 있습니다.", HttpStatus.BAD_REQUEST),
+    INVALID_CREW_NAME_CHARACTERS("INVALID_CREW_NAME_CHARACTERS", "크루 이름은 한글, 영문, 숫자만 사용할 수 있습니다.", HttpStatus.BAD_REQUEST),
 
     // 일정 관련
     INVALID_SCHEDULE_TIME("INVALID_SCHEDULE_TIME", "유효하지 않은 일정 시간입니다.", HttpStatus.BAD_REQUEST),

--- a/src/test/java/com/youthexpedition/azit/modules/crew/domain/model/CrewTest.java
+++ b/src/test/java/com/youthexpedition/azit/modules/crew/domain/model/CrewTest.java
@@ -19,7 +19,7 @@ class CrewTest {
     @DisplayName("크루 생성 시 6자리의 영문 대문자 및 숫자 조합 초대 코드가 생성된다.")
     void create_success() {
         // given
-        String name = "서울 러닝 크루";
+        String name = "서울러닝크루";
         CrewCategory category = CrewCategory.RUNNING;
         Region region = Region.SEOUL;
         String invitationCode = "ABC123";
@@ -29,7 +29,7 @@ class CrewTest {
         Crew crew = Crew.create(name, category, region, imageUrl, invitationCode);
 
         // then
-        assertThat(crew.getName()).isEqualTo(name);
+        assertThat(crew.getName()).isEqualTo("서울러닝크루");
         assertThat(crew.getInvitationCode()).hasSize(6);
         assertThat(crew.getInvitationCode()).matches("^[A-Z0-9]{6}$");
     }
@@ -40,7 +40,7 @@ class CrewTest {
 
         @ParameterizedTest(name = "예약어 포함 크루명 \"{0}\" 으로 생성 시 예외 발생")
         @ValueSource(strings = {
-                "AZIT 러닝", "azit크루", "아지트크루", "관리자크루", "어드민크루",
+                "AZIT러닝", "azit크루", "아지트크루", "관리자크루", "어드민크루",
                 "Admin크루", "admin크루", "공식크루", "Official러닝", "official크루",
                 "운영진크루", "스태프크루", "Staff러닝", "staff크루",
                 "스폰서크루", "Sponsor러닝", "sponsor크루", "제휴크루", "파트너크루",
@@ -58,10 +58,10 @@ class CrewTest {
         @DisplayName("크루명 수정 시 예약어가 포함되면 예외가 발생한다.")
         void updateInfo_throwsException_whenNameContainsReservedKeyword() {
             // given
-            Crew crew = Crew.create("서울 러닝 크루", CrewCategory.RUNNING, Region.SEOUL, "img.png", "ABC123");
+            Crew crew = Crew.create("서울러닝크루", CrewCategory.RUNNING, Region.SEOUL, "img.png", "ABC123");
 
             // when & then
-            assertThatThrownBy(() -> crew.updateInfo("AZIT 공식 크루", "설명"))
+            assertThatThrownBy(() -> crew.updateInfo("AZIT공식크루", "설명"))
                     .isInstanceOf(BusinessException.class)
                     .hasFieldOrPropertyWithValue("errorCode", CrewErrorCode.RESERVED_CREW_NAME_KEYWORD);
         }
@@ -70,13 +70,13 @@ class CrewTest {
         @DisplayName("예약어가 없는 크루명으로 수정 시 정상 반영된다.")
         void updateInfo_success_whenNameHasNoReservedKeyword() {
             // given
-            Crew crew = Crew.create("서울 러닝 크루", CrewCategory.RUNNING, Region.SEOUL, "img.png", "ABC123");
+            Crew crew = Crew.create("서울러닝크루", CrewCategory.RUNNING, Region.SEOUL, "img.png", "ABC123");
 
             // when
-            crew.updateInfo("한강 러닝 크루", "한강에서 달리는 크루");
+            crew.updateInfo("한강러닝크루", "한강에서 달리는 크루");
 
             // then
-            assertThat(crew.getName()).isEqualTo("한강 러닝 크루");
+            assertThat(crew.getName()).isEqualTo("한강러닝크루");
         }
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈
- 해당 없음

## ✨ 작업 내용
> 크루 이름 생성 및 수정 시 한글, 영문, 숫자 이외의 문자(특수문자, 공백 등)를 사용할 수 없도록 검증 로직을 추가했습니다.

- `Crew.validateName()`에 정규식 검증 추가 (`^[가-힣a-zA-Z0-9]+$`)
- `CrewErrorCode`에 `INVALID_CREW_NAME_CHARACTERS` 에러코드 추가
- 크루 생성(`create`)과 정보 수정(`updateInfo`) 모두 동일하게 적용

## 🧱 아키텍처 변경 요약
- `Crew` 도메인 모델 내 `validateName()` 메서드에 문자 제한 로직 추가

## 📸 스크린샷 (선택 사항)

## ⚠️ 주의 사항 (선택)
- [ ] DB 스키마 변경이 있나요?
- [ ] API 명세(Swagger)가 업데이트 되었나요?
- [ ] 새로운 환경 변수(.env)가 추가 되었나요?

## ✅ 셀프 체크리스트
- [ ] 브랜치 전략(develop)에 맞게 올렸나요?
- [ ] 커밋 컨벤션을 준수했나요?
- [ ] 불필요한 주석이나 print문은 제거했나요?
- [ ] 로컬에서 테스트는 성공했나요?