### PR TITLE
[FIX] 카카오 프로필 이미지 유지 시 IMAGE_NOT_UPLOADED 오류 수정

### DIFF
--- a/src/main/java/com/youthexpedition/azit/infrastructure/common/util/image/ImageUpdateUtil.java
+++ b/src/main/java/com/youthexpedition/azit/infrastructure/common/util/image/ImageUpdateUtil.java
@@ -16,6 +16,8 @@ public class ImageUpdateUtil {
 
     public static final String DEFAULT_S3_PREFIX = "default/";
     public static final String DEFAULT_SLASH = "/";
+    public static final String HTTP_PREFIX = "http://";
+    public static final String HTTPS_PREFIX = "https://";
 
     private final ImageUrlFormatUtil imageUrlFormatUtil;
     private final ImageStoragePort imageStoragePort;
@@ -39,7 +41,7 @@ public class ImageUpdateUtil {
 
         // 외부 URL(카카오 등 소셜 프로필)인 경우 형식 검증 후 URL 그대로 반영
         if (allowExternalUrl && incomingS3Key == null) {
-            if (!incomingUrl.startsWith("http://") && !incomingUrl.startsWith("https://")) {
+            if (incomingUrl != null && !incomingUrl.isBlank() && !incomingUrl.startsWith(HTTP_PREFIX) && !incomingUrl.startsWith(HTTPS_PREFIX)) {
                 throw new BusinessException(ImageErrorCode.IMAGE_NOT_UPLOADED);
             }
             deleteOldCustomImage(currentS3Key);

--- a/src/main/java/com/youthexpedition/azit/infrastructure/common/util/image/ImageUpdateUtil.java
+++ b/src/main/java/com/youthexpedition/azit/infrastructure/common/util/image/ImageUpdateUtil.java
@@ -37,8 +37,11 @@ public class ImageUpdateUtil {
 
         if (!imageChanged) return;
 
-        // 외부 URL(카카오 등 소셜 프로필)인 경우 S3 검증 없이 URL 그대로 반영
+        // 외부 URL(카카오 등 소셜 프로필)인 경우 형식 검증 후 URL 그대로 반영
         if (allowExternalUrl && incomingS3Key == null) {
+            if (!incomingUrl.startsWith("http://") && !incomingUrl.startsWith("https://")) {
+                throw new BusinessException(ImageErrorCode.IMAGE_NOT_UPLOADED);
+            }
             deleteOldCustomImage(currentS3Key);
             updateUrl.accept(incomingUrl);
             return;

--- a/src/main/java/com/youthexpedition/azit/infrastructure/common/util/image/ImageUpdateUtil.java
+++ b/src/main/java/com/youthexpedition/azit/infrastructure/common/util/image/ImageUpdateUtil.java
@@ -37,6 +37,13 @@ public class ImageUpdateUtil {
 
         if (!imageChanged) return;
 
+        // 외부 URL(카카오 등 소셜 프로필)인 경우 S3 검증 없이 URL 그대로 반영
+        if (allowExternalUrl && incomingS3Key == null) {
+            deleteOldCustomImage(currentS3Key);
+            updateUrl.accept(incomingUrl);
+            return;
+        }
+
         if (incomingS3Key == null) {
             throw new BusinessException(ImageErrorCode.IMAGE_NOT_UPLOADED);
         }

--- a/src/main/java/com/youthexpedition/azit/modules/member/adapter/in/web/docs/MemberControllerDocs.java
+++ b/src/main/java/com/youthexpedition/azit/modules/member/adapter/in/web/docs/MemberControllerDocs.java
@@ -83,7 +83,7 @@ public interface MemberControllerDocs {
             * REQUESTED: 승인 대기 상태. memberRole 은 null 입니다. <br><br>
 
             **[참고 사항]** <br>
-            * invitationCode: 사용자가 해당 크루의 리더이면서 JOINED 상태일 때만 값이 존재하며, 그 외의 경우에는 null로 내려갑니다.
+            * invitationCode: JOINED 상태일 때 값이 존재하며, 그 외의 경우(REQUESTED 등)에는 null로 내려갑니다.
             """
     )
     @ApiErrorCodeExamples({

--- a/src/main/java/com/youthexpedition/azit/modules/member/application/service/mapper/MemberResponseMapper.java
+++ b/src/main/java/com/youthexpedition/azit/modules/member/application/service/mapper/MemberResponseMapper.java
@@ -27,9 +27,8 @@ public class MemberResponseMapper {
     }
 
     public MyCrewResponse toMyCrewResponse(CrewMember crewMember, Crew crew) {
-        // 리더이면서 JOINED 상태일 때만 초대 코드 노출
-        String invitationCode = (crewMember.getRole() == CrewMemberRole.LEADER
-                && crewMember.getStatus() == CrewMemberStatus.JOINED)
+        // JOINED 상태일 때 초대 코드 노출
+        String invitationCode = crewMember.getStatus() == CrewMemberStatus.JOINED
                 ? crew.getInvitationCode() : null;
 
         return MyCrewResponse.of(


### PR DESCRIPTION
## 📌 관련 이슈
- 해당 없음

## ✨ 작업 내용
> 가입 후 최초 프로필 수정 시 사진을 변경하지 않으면 `IMAGE_NOT_UPLOADED` 에러가 발생하는 버그를 수정했습니다.

**원인**
- Kakao 프로필 URL이 DB에는 `http://`로 저장되어 있고, 응답 시 `buildFullImageUrl`이 `https://`로 변환해서 내려줌
- 프론트가 그대로 `https://` URL을 요청에 담아 보내면 DB의 `http://` URL과 달라 `imageChanged = true`가 됨
- `incomingS3Key == null`이라 `IMAGE_NOT_UPLOADED` 예외 발생
- 한 번 S3에 업로드 후에는 S3 URL이 저장되어 이 문제가 발생하지 않아 초기 1회에만 재현됨

**수정 내용**
- `ImageUpdateUtil.update()`에서 `allowExternalUrl = true`이고 `incomingS3Key == null`인 경우(외부 URL), S3 검증 없이 URL을 그대로 반영하도록 처리
- 멤버일 경우도 초대코드 반환하도록 수정

## 🧱 아키텍처 변경 요약
- 해당 없음

## 📸 스크린샷 (선택 사항)

## ⚠️ 주의 사항 (선택)
- [ ] DB 스키마 변경이 있나요?
- [ ] API 명세(Swagger)가 업데이트 되었나요?
- [ ] 새로운 환경 변수(.env)가 추가 되었나요?

## ✅ 셀프 체크리스트
- [ ] 브랜치 전략(develop)에 맞게 올렸나요?
- [ ] 커밋 컨벤션을 준수했나요?
- [ ] 불필요한 주석이나 print문은 제거했나요?
- [ ] 로컬에서 테스트는 성공했나요?