### PR TITLE
[FIX] 강제 탈퇴 시 member_terms_consent FK 제약 위반 수정

### DIFF
--- a/src/main/java/com/youthexpedition/azit/modules/member/adapter/out/persistence/TermsPersistenceAdapter.java
+++ b/src/main/java/com/youthexpedition/azit/modules/member/adapter/out/persistence/TermsPersistenceAdapter.java
@@ -71,6 +71,11 @@ public class TermsPersistenceAdapter implements LoadTermsVersionPort, SaveMember
     }
 
     @Override
+    public void deleteHistoryByMemberId(Long memberId) {
+        memberTermsConsentHistoryRepository.deleteByMemberId(memberId);
+    }
+
+    @Override
     public void saveAllHistory(List<MemberTermsConsentHistory> histories) {
         memberTermsConsentHistoryRepository.saveAll(
                 histories.stream()

--- a/src/main/java/com/youthexpedition/azit/modules/member/adapter/out/persistence/TermsPersistenceAdapter.java
+++ b/src/main/java/com/youthexpedition/azit/modules/member/adapter/out/persistence/TermsPersistenceAdapter.java
@@ -66,6 +66,11 @@ public class TermsPersistenceAdapter implements LoadTermsVersionPort, SaveMember
     }
 
     @Override
+    public void deleteByMemberId(Long memberId) {
+        memberTermsConsentRepository.deleteByMemberId(memberId);
+    }
+
+    @Override
     public void saveAllHistory(List<MemberTermsConsentHistory> histories) {
         memberTermsConsentHistoryRepository.saveAll(
                 histories.stream()

--- a/src/main/java/com/youthexpedition/azit/modules/member/adapter/out/persistence/repository/MemberTermsConsentHistoryRepository.java
+++ b/src/main/java/com/youthexpedition/azit/modules/member/adapter/out/persistence/repository/MemberTermsConsentHistoryRepository.java
@@ -2,6 +2,13 @@ package com.youthexpedition.azit.modules.member.adapter.out.persistence.reposito
 
 import com.youthexpedition.azit.modules.member.adapter.out.persistence.entity.MemberTermsConsentHistoryEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface MemberTermsConsentHistoryRepository extends JpaRepository<MemberTermsConsentHistoryEntity, Long> {
+
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM MemberTermsConsentHistoryEntity h WHERE h.memberId = :memberId")
+    void deleteByMemberId(@Param("memberId") Long memberId);
 }

--- a/src/main/java/com/youthexpedition/azit/modules/member/adapter/out/persistence/repository/MemberTermsConsentRepository.java
+++ b/src/main/java/com/youthexpedition/azit/modules/member/adapter/out/persistence/repository/MemberTermsConsentRepository.java
@@ -22,4 +22,8 @@ public interface MemberTermsConsentRepository extends JpaRepository<MemberTermsC
     @Modifying(clearAutomatically = true)
     @Query("DELETE FROM MemberTermsConsentEntity c WHERE c.memberId = :memberId AND c.termsVersionId IN :versionIds")
     void deleteByMemberIdAndTermsVersionIdIn(@Param("memberId") Long memberId, @Param("versionIds") Collection<Long> versionIds);
+
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM MemberTermsConsentEntity c WHERE c.memberId = :memberId")
+    void deleteByMemberId(@Param("memberId") Long memberId);
 }

--- a/src/main/java/com/youthexpedition/azit/modules/member/application/port/out/SaveMemberTermsConsentPort.java
+++ b/src/main/java/com/youthexpedition/azit/modules/member/application/port/out/SaveMemberTermsConsentPort.java
@@ -12,5 +12,6 @@ public interface SaveMemberTermsConsentPort {
     void updateAgreedAt(Long memberId, Set<Long> versionIds, LocalDateTime agreedAt);
     void deleteByMemberIdAndVersionIds(Long memberId, Set<Long> versionIds);
     void deleteByMemberId(Long memberId);
+    void deleteHistoryByMemberId(Long memberId);
     void saveAllHistory(List<MemberTermsConsentHistory> histories);
 }

--- a/src/main/java/com/youthexpedition/azit/modules/member/application/port/out/SaveMemberTermsConsentPort.java
+++ b/src/main/java/com/youthexpedition/azit/modules/member/application/port/out/SaveMemberTermsConsentPort.java
@@ -11,5 +11,6 @@ public interface SaveMemberTermsConsentPort {
     void saveAll(List<MemberTermsConsent> consents);
     void updateAgreedAt(Long memberId, Set<Long> versionIds, LocalDateTime agreedAt);
     void deleteByMemberIdAndVersionIds(Long memberId, Set<Long> versionIds);
+    void deleteByMemberId(Long memberId);
     void saveAllHistory(List<MemberTermsConsentHistory> histories);
 }

--- a/src/main/java/com/youthexpedition/azit/modules/test/application/service/TestMemberService.java
+++ b/src/main/java/com/youthexpedition/azit/modules/test/application/service/TestMemberService.java
@@ -13,6 +13,7 @@ import com.youthexpedition.azit.modules.crew.domain.model.enums.CrewMemberStatus
 import com.youthexpedition.azit.modules.member.application.port.out.LoadMemberPort;
 import com.youthexpedition.azit.modules.member.application.port.out.SaveDeliveryAddressPort;
 import com.youthexpedition.azit.modules.member.application.port.out.SaveMemberPort;
+import com.youthexpedition.azit.modules.member.application.port.out.SaveMemberTermsConsentPort;
 import com.youthexpedition.azit.modules.member.application.port.out.SavePointHistoryPort;
 import com.youthexpedition.azit.modules.member.domain.model.Member;
 import com.youthexpedition.azit.modules.member.domain.model.enums.MemberErrorCode;
@@ -43,6 +44,7 @@ public class TestMemberService implements TestMemberUseCase {
     private final SavePointHistoryPort savePointHistoryPort;
     private final SaveCartItemPort saveCartItemPort;
     private final SaveDeliveryAddressPort saveDeliveryAddressPort;
+    private final SaveMemberTermsConsentPort saveMemberTermsConsentPort;
     private final SaveMemberPort saveMemberPort;
     private final TokenPort tokenPort;
 
@@ -72,6 +74,9 @@ public class TestMemberService implements TestMemberUseCase {
 
         // delivery_address 완전 삭제
         saveDeliveryAddressPort.deleteByMemberId(memberId);
+
+        // member_terms_consent 완전 삭제
+        saveMemberTermsConsentPort.deleteByMemberId(memberId);
 
         // 소셜 연동 해제
         socialAuthPort.revoke(SocialRevokeCommand.from(member));

--- a/src/main/java/com/youthexpedition/azit/modules/test/application/service/TestMemberService.java
+++ b/src/main/java/com/youthexpedition/azit/modules/test/application/service/TestMemberService.java
@@ -75,6 +75,9 @@ public class TestMemberService implements TestMemberUseCase {
         // delivery_address 완전 삭제
         saveDeliveryAddressPort.deleteByMemberId(memberId);
 
+        // member_terms_consent_history 완전 삭제
+        saveMemberTermsConsentPort.deleteHistoryByMemberId(memberId);
+
         // member_terms_consent 완전 삭제
         saveMemberTermsConsentPort.deleteByMemberId(memberId);
 


### PR DESCRIPTION
## 📌 관련 이슈
- 해당 없음

## ✨ 작업 내용
> 테스트용 강제 탈퇴 API 호출 시 `member_terms_consent` 테이블의 FK 제약으로 인해 500 에러가 발생하던 문제를 수정했습니다.

**원인**
- `forceWithdraw`는 `member` 레코드를 하드 딜리트하는데, `member_terms_consent` 테이블이 `member.id`를 FK로 참조하고 있어 삭제 순서가 맞지 않아 `SQLIntegrityConstraintViolationException` 발생

**수정 내용**
- `MemberTermsConsentRepository`에 `deleteByMemberId` 쿼리 추가
- `SaveMemberTermsConsentPort`에 `deleteByMemberId` 메서드 추가
- `TermsPersistenceAdapter`에 구현 추가
- `TestMemberService.forceWithdraw()`에서 `member` 삭제 전 `member_terms_consent` 먼저 삭제하도록 추가

## 🧱 아키텍처 변경 요약
- 해당 없음

## 📸 스크린샷 (선택 사항)

## ⚠️ 주의 사항 (선택)
- [ ] DB 스키마 변경이 있나요?
- [ ] API 명세(Swagger)가 업데이트 되었나요?
- [ ] 새로운 환경 변수(.env)가 추가 되었나요?

## ✅ 셀프 체크리스트
- [ ] 브랜치 전략(develop)에 맞게 올렸나요?
- [ ] 커밋 컨벤션을 준수했나요?
- [ ] 불필요한 주석이나 print문은 제거했나요?
- [ ] 로컬에서 테스트는 성공했나요?