### PR TITLE
[FEAT] 내 출석 로그 목록 조회 응답에 크루명/최대·현재 참여 인원 추가

### DIFF
--- a/src/main/java/com/youthexpedition/azit/modules/crew/application/service/CrewScheduleService.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/application/service/CrewScheduleService.java
@@ -11,11 +11,13 @@ import com.youthexpedition.azit.modules.crew.application.port.in.dto.*;
 import com.youthexpedition.azit.modules.crew.application.port.in.query.CrewScheduleMonthlyQuery;
 import com.youthexpedition.azit.modules.crew.application.port.in.query.CrewScheduleQuery;
 import com.youthexpedition.azit.modules.crew.application.port.out.LoadCrewMemberPort;
+import com.youthexpedition.azit.modules.crew.application.port.out.LoadCrewPort;
 import com.youthexpedition.azit.modules.crew.application.port.out.LoadCrewSchedulePort;
 import com.youthexpedition.azit.modules.crew.application.port.out.SaveCrewSchedulePort;
 import com.youthexpedition.azit.modules.crew.application.port.out.query.MemberProfileDto;
 import com.youthexpedition.azit.modules.crew.application.service.dto.ScheduleData;
 import com.youthexpedition.azit.modules.crew.application.service.mapper.CrewScheduleResponseMapper;
+import com.youthexpedition.azit.modules.crew.domain.model.Crew;
 import com.youthexpedition.azit.modules.crew.domain.model.CrewMember;
 import com.youthexpedition.azit.modules.crew.domain.model.CrewSchedule;
 import com.youthexpedition.azit.modules.crew.domain.model.Location;
@@ -49,6 +51,7 @@ import java.util.stream.Collectors;
 @Transactional(readOnly = true)
 public class CrewScheduleService implements CrewScheduleUseCase {
     private final LoadCrewMemberPort loadCrewMemberPort;
+    private final LoadCrewPort loadCrewPort;
     private final LoadCrewSchedulePort loadCrewSchedulePort;
     private final SaveCrewSchedulePort saveCrewSchedulePort;
     private final LoadMemberPort loadMemberPort;
@@ -426,7 +429,15 @@ public class CrewScheduleService implements CrewScheduleUseCase {
         List<CrewSchedule> schedules = loadCrewSchedulePort.findAllByMemberIdAndMonth(
                 query.memberId(), query.yearMonth(), now, query.crewId());
 
-        List<MyAttendanceLogResponse.DailyAttendanceLog> attendanceLogs = crewScheduleResponseMapper.toDailyAttendanceLogs(schedules, query.memberId());
+        // 각 일정의 크루명 조회
+        List<Long> crewIds = schedules.stream()
+                .map(CrewSchedule::getCrewId)
+                .distinct()
+                .toList();
+        Map<Long, String> crewNameMap = loadCrewPort.findAllByIds(crewIds).stream()
+                .collect(Collectors.toMap(Crew::getId, Crew::getName));
+
+        List<MyAttendanceLogResponse.DailyAttendanceLog> attendanceLogs = crewScheduleResponseMapper.toDailyAttendanceLogs(schedules, query.memberId(), crewNameMap);
 
         // 총 출석 날짜 계산
         int attendanceCount = (int) schedules.stream()

--- a/src/main/java/com/youthexpedition/azit/modules/crew/application/service/CrewScheduleService.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/application/service/CrewScheduleService.java
@@ -434,7 +434,7 @@ public class CrewScheduleService implements CrewScheduleUseCase {
                 .map(CrewSchedule::getCrewId)
                 .distinct()
                 .toList();
-        Map<Long, String> crewNameMap = loadCrewPort.findAllByIds(crewIds).stream()
+        Map<Long, String> crewNameMap = crewIds.isEmpty() ? Map.of() : loadCrewPort.findAllByIds(crewIds).stream()
                 .collect(Collectors.toMap(Crew::getId, Crew::getName));
 
         List<MyAttendanceLogResponse.DailyAttendanceLog> attendanceLogs = crewScheduleResponseMapper.toDailyAttendanceLogs(schedules, query.memberId(), crewNameMap);

--- a/src/main/java/com/youthexpedition/azit/modules/crew/application/service/mapper/CrewScheduleResponseMapper.java
+++ b/src/main/java/com/youthexpedition/azit/modules/crew/application/service/mapper/CrewScheduleResponseMapper.java
@@ -173,7 +173,7 @@ public class CrewScheduleResponseMapper {
         return MyAttendanceLogResponse.of(attendanceCount, totalPoints, attendanceLogs);
     }
 
-    public List<MyAttendanceLogResponse.DailyAttendanceLog> toDailyAttendanceLogs(List<CrewSchedule> schedules, Long memberId) {
+    public List<MyAttendanceLogResponse.DailyAttendanceLog> toDailyAttendanceLogs(List<CrewSchedule> schedules, Long memberId, Map<Long, String> crewNameMap) {
         return schedules.stream()
                 .map(s -> {
                     boolean isCheckedIn = s.isCheckedIn(memberId);
@@ -181,11 +181,14 @@ public class CrewScheduleResponseMapper {
 
                     return MyAttendanceLogResponse.DailyAttendanceLog.of(
                             s.getId(),
+                            crewNameMap.get(s.getCrewId()),
                             s.getTitle(),
                             s.getRunType(),
                             s.getMeetingAt(),
                             s.getLocation().getPlaceName(),
-                            status
+                            status,
+                            s.getMaxParticipants(),
+                            s.getParticipantIds().size()
                     );
                 })
                 .toList();

--- a/src/main/java/com/youthexpedition/azit/modules/member/application/port/in/dto/MyAttendanceLogResponse.java
+++ b/src/main/java/com/youthexpedition/azit/modules/member/application/port/in/dto/MyAttendanceLogResponse.java
@@ -20,6 +20,8 @@ public record MyAttendanceLogResponse(
     public record DailyAttendanceLog(
             @Schema(description = "일정 ID")
             Long scheduleId,
+            @Schema(description = "크루명")
+            String crewName,
             @Schema(description = "일정 제목")
             String title,
             @Schema(description = "러닝 타입")
@@ -30,11 +32,17 @@ public record MyAttendanceLogResponse(
             @Schema(description = "집합 장소명")
             String placeName,
             @Schema(description = "출석 상태")
-            AttendanceStatus status
+            AttendanceStatus status,
+            @Schema(description = "최대 인원")
+            Integer maxParticipants,
+            @Schema(description = "현재 참여 인원")
+            Integer currentParticipants
     ) {
-        public static DailyAttendanceLog of(Long scheduleId, String title, RunType runType,
-                                            LocalDateTime meetingAt, String placeName, AttendanceStatus status) {
-            return new DailyAttendanceLog(scheduleId, title, runType, meetingAt, placeName, status);
+        public static DailyAttendanceLog of(Long scheduleId, String crewName, String title, RunType runType,
+                                            LocalDateTime meetingAt, String placeName, AttendanceStatus status,
+                                            Integer maxParticipants, Integer currentParticipants) {
+            return new DailyAttendanceLog(scheduleId, crewName, title, runType, meetingAt, placeName, status,
+                    maxParticipants, currentParticipants);
         }
     }
 


### PR DESCRIPTION
## 📌 관련 이슈
-

## ✨ 작업 내용
> 이번 PR에서 변경된 핵심 내용을 요약해주세요.

- 내 출석 로그 목록 조회 API(`GET /api/v1/members/me/attendances`) 응답의 각 출석 항목에 `crewName`(크루명), `maxParticipants`(최대 인원), `currentParticipants`(현재 참여 인원) 필드를 추가했습니다.
- `CrewScheduleService.getMyAttendanceLogs`에서 조회된 일정들의 크루 ID를 모아 기존 `LoadCrewPort.findAllByIds()` 한 번 호출로 크루명 맵을 구성해 매퍼에 전달합니다. (N+1 없음)
- `currentParticipants`는 일정 참여 명단(`participants`) 크기 기준으로 계산합니다.

## 🧱 아키텍처 변경 요약
> 이번 작업으로 인해 변경된 주요 흐름을 적어주세요. (없으면 생략 가능)

- `CrewScheduleService`에 기존 아웃바운드 포트 `LoadCrewPort` 의존성 추가 (신규 포트/어댑터 없음)
- `CrewScheduleResponseMapper.toDailyAttendanceLogs` 시그니처에 크루명 맵(`Map<Long, String>`) 파라미터 추가

## 📸 스크린샷 (선택 사항)
> API 테스트 결과 등을 첨부해주세요.

## ⚠️ 주의 사항 (선택)
- [ ] DB 스키마 변경이 있나요?
- [x] API 명세(Swagger)가 업데이트 되었나요?
- [ ] 새로운 환경 변수(.env)가 추가 되었나요?

## ✅ 셀프 체크리스트
- [ ] 브랜치 전략(develop)에 맞게 올렸나요?
- [ ] 커밋 컨벤션을 준수했나요?
- [ ] 불필요한 주석이나 print문은 제거했나요?
- [ ] 로컬에서 테스트는 성공했나요?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
