### PR TITLE
[FIX] 탈퇴 시 크루 가입 상태별 EXITED/CANCELLED 분기 처리

### DIFF
--- a/src/main/java/com/youthexpedition/azit/modules/member/application/service/MemberService.java
+++ b/src/main/java/com/youthexpedition/azit/modules/member/application/service/MemberService.java
@@ -116,11 +116,13 @@ public class MemberService implements MemberUseCase {
         // 이미 탈퇴한 회원인지 확인
         member.validateNotWithdrawn();
 
+        List<CrewMember> activeCrewMembers = loadCrewMemberPort.findAllActiveByMemberId(memberId);
+
         // 탈퇴 가능한지 확인
-        validateWithdrawal(memberId);
+        validateWithdrawal(memberId, activeCrewMembers);
 
         // 가입한 크루 인원 수 차감 및 상태 변경
-        processCrewWithdrawal(memberId);
+        processCrewWithdrawal(memberId, activeCrewMembers);
 
         // 탈퇴 상태로 변경 (소셜 연동 해제 및 개인정보 파기는 유예기간 만료 후 배치에서 처리)
         member.withdraw(LocalDateTime.now());
@@ -142,11 +144,13 @@ public class MemberService implements MemberUseCase {
             return;
         }
 
+        List<CrewMember> activeCrewMembers = loadCrewMemberPort.findAllActiveByMemberId(member.getId());
+
         // 탈퇴 가능한지 확인
-        validateWithdrawal(member.getId());
+        validateWithdrawal(member.getId(), activeCrewMembers);
 
         // 가입한 크루 인원 수 차감 및 상태 변경
-        processCrewWithdrawal(member.getId());
+        processCrewWithdrawal(member.getId(), activeCrewMembers);
 
         // 탈퇴 상태로 변경 (개인정보 파기는 유예기간 만료 후 배치에서 처리)
         member.withdraw(LocalDateTime.now());
@@ -219,8 +223,7 @@ public class MemberService implements MemberUseCase {
                 .orElseThrow(() -> new BusinessException(MemberErrorCode.MEMBER_NOT_FOUND));
     }
 
-    private void processCrewWithdrawal(Long memberId) {
-        List<CrewMember> crewMembers = loadCrewMemberPort.findAllByMemberId(memberId);
+    private void processCrewWithdrawal(Long memberId, List<CrewMember> crewMembers) {
         if (crewMembers.isEmpty()) return;
 
         // 가입 상태인 크루 ID 추출
@@ -235,16 +238,22 @@ public class MemberService implements MemberUseCase {
             saveCrewPort.decrementMemberCountBatch(joinedCrewIds);
         }
 
-        // 가입한 모든 크루 상태를 EXITED로 변경 및 저장
+        // 가입 완료 상태는 탈퇴(EXITED)로, 가입 신청 상태는 신청 취소(CANCELLED)로 변경 및 저장
         LocalDateTime now = LocalDateTime.now();
-        crewMembers.forEach(cm -> cm.exit(now));
+        crewMembers.forEach(cm -> {
+            if (cm.getStatus() == CrewMemberStatus.JOINED) {
+                cm.exit(now);
+            } else if (cm.getStatus() == CrewMemberStatus.REQUESTED) {
+                cm.cancel(now);
+            }
+        });
         saveCrewMemberPort.saveAll(crewMembers);
     }
 
     // 본인이 리더인 크루가 있으면 앱 탈퇴 불가
-    private void validateWithdrawal(Long memberId) {
+    private void validateWithdrawal(Long memberId, List<CrewMember> activeCrewMembers) {
         // 사용자가 JOINED 상태이면서 리더인 크루 조회
-        List<CrewMember> crewMembersAsLeader = loadCrewMemberPort.findAllActiveByMemberId(memberId).stream()
+        List<CrewMember> crewMembersAsLeader = activeCrewMembers.stream()
                 .filter(cm -> cm.getStatus() == CrewMemberStatus.JOINED)
                 .filter(cm -> cm.getRole() == CrewMemberRole.LEADER)
                 .toList();

--- a/src/test/java/com/youthexpedition/azit/modules/member/application/service/MemberServiceTest.java
+++ b/src/test/java/com/youthexpedition/azit/modules/member/application/service/MemberServiceTest.java
@@ -6,6 +6,7 @@ import com.youthexpedition.azit.modules.auth.application.port.out.TokenPort;
 import com.youthexpedition.azit.modules.crew.application.port.out.LoadCrewMemberPort;
 import com.youthexpedition.azit.modules.crew.application.port.out.LoadCrewPort;
 import com.youthexpedition.azit.modules.crew.application.port.out.SaveCrewMemberPort;
+import com.youthexpedition.azit.modules.crew.application.port.out.SaveCrewPort;
 import com.youthexpedition.azit.modules.crew.domain.model.Crew;
 import com.youthexpedition.azit.modules.crew.domain.model.CrewMember;
 import com.youthexpedition.azit.modules.crew.domain.model.enums.CrewMemberRole;
@@ -57,6 +58,8 @@ class MemberServiceTest {
     @Mock
     private SaveCrewMemberPort saveCrewMemberPort;
     @Mock
+    private SaveCrewPort saveCrewPort;
+    @Mock
     private LoadCrewMemberPort loadCrewMemberPort;
     @Mock
     private LoadCrewPort loadCrewPort;
@@ -88,7 +91,6 @@ class MemberServiceTest {
             // given
             doReturn(Optional.of(member)).when(loadMemberPort).findById(memberId);
             doReturn(List.of()).when(loadCrewMemberPort).findAllActiveByMemberId(memberId);
-            doReturn(List.of()).when(loadCrewMemberPort).findAllByMemberId(memberId);
             doNothing().when(tokenPort).deleteByMemberId(memberId);
             doNothing().when(tokenPort).addToBlacklist(anyString(), anyString());
             doReturn(member).when(saveMemberPort).save(any(Member.class));
@@ -99,12 +101,47 @@ class MemberServiceTest {
             // then
             verify(loadMemberPort, times(1)).findById(memberId);
             verify(loadCrewMemberPort, times(1)).findAllActiveByMemberId(memberId);
-            verify(loadCrewMemberPort, times(1)).findAllByMemberId(memberId);
             verify(tokenPort, times(1)).deleteByMemberId(memberId);
             verify(tokenPort, times(1)).addToBlacklist(accessToken, "withdrawn");
             verify(saveMemberPort, times(1)).save(member);
             assertTrue(member.isWithdrawn());
             assertNotNull(member.getWithdrawnAt()); // 유예기간 계산 기준 시각 기록
+        }
+
+        @Test
+        @DisplayName("성공 - JOINED 상태는 탈퇴(EXITED)로, REQUESTED 상태는 신청 취소(CANCELLED)로 변경")
+        void withdraw_success_appliesExitOrCancelByStatus() {
+            // given
+            CrewMember joinedCrewMember = CrewMember.builder()
+                    .crewId(10L)
+                    .memberId(memberId)
+                    .role(CrewMemberRole.MEMBER)
+                    .status(CrewMemberStatus.JOINED)
+                    .build();
+            CrewMember requestedCrewMember = CrewMember.builder()
+                    .crewId(20L)
+                    .memberId(memberId)
+                    .role(CrewMemberRole.MEMBER)
+                    .status(CrewMemberStatus.REQUESTED)
+                    .build();
+
+            doReturn(Optional.of(member)).when(loadMemberPort).findById(memberId);
+            doReturn(List.of(joinedCrewMember, requestedCrewMember)).when(loadCrewMemberPort).findAllActiveByMemberId(memberId);
+            doNothing().when(saveCrewPort).decrementMemberCountBatch(anyList());
+            doNothing().when(saveCrewMemberPort).saveAll(anyList());
+            doNothing().when(tokenPort).deleteByMemberId(memberId);
+            doNothing().when(tokenPort).addToBlacklist(anyString(), anyString());
+            doReturn(member).when(saveMemberPort).save(any(Member.class));
+
+            // when
+            memberService.withdraw(memberId, accessToken);
+
+            // then
+            verify(saveCrewPort, times(1)).decrementMemberCountBatch(List.of(10L)); // JOINED 크루만 인원수 차감
+            assertThat(joinedCrewMember.getStatus()).isEqualTo(CrewMemberStatus.EXITED);
+            assertThat(joinedCrewMember.getExitedAt()).isNotNull();
+            assertThat(requestedCrewMember.getStatus()).isEqualTo(CrewMemberStatus.CANCELLED);
+            assertThat(requestedCrewMember.getCancelledAt()).isNotNull();
         }
 
         @Test
@@ -139,7 +176,7 @@ class MemberServiceTest {
             );
 
             assertEquals(MemberErrorCode.MEMBER_ALREADY_WITHDRAWN.getCode(), exception.getErrorCode().getCode());
-            verify(loadCrewMemberPort, never()).findAllByMemberId(anyLong());
+            verify(loadCrewMemberPort, never()).findAllActiveByMemberId(anyLong());
             verify(tokenPort, never()).deleteByMemberId(anyLong());
             verify(saveMemberPort, never()).save(any(Member.class));
         }
@@ -150,7 +187,6 @@ class MemberServiceTest {
             // given
             doReturn(Optional.of(member)).when(loadMemberPort).findById(memberId);
             doReturn(List.of()).when(loadCrewMemberPort).findAllActiveByMemberId(memberId);
-            doReturn(List.of()).when(loadCrewMemberPort).findAllByMemberId(memberId);
             doThrow(new RuntimeException("Token deletion failed")).when(tokenPort).deleteByMemberId(memberId);
 
             // when & then
@@ -160,7 +196,6 @@ class MemberServiceTest {
 
             verify(loadMemberPort, times(1)).findById(memberId);
             verify(loadCrewMemberPort, times(1)).findAllActiveByMemberId(memberId);
-            verify(loadCrewMemberPort, times(1)).findAllByMemberId(memberId);
             verify(tokenPort, times(1)).deleteByMemberId(memberId);
             verify(tokenPort, never()).addToBlacklist(anyString(), anyString());
             verify(saveMemberPort, never()).save(any(Member.class));
@@ -183,7 +218,7 @@ class MemberServiceTest {
             memberService.withdrawBySocialInfo("appleSub", SocialProvider.APPLE);
 
             // then
-            verify(loadCrewMemberPort, never()).findAllByMemberId(anyLong());
+            verify(loadCrewMemberPort, never()).findAllActiveByMemberId(anyLong());
             verify(tokenPort, never()).deleteByMemberId(anyLong());
             verify(saveMemberPort, never()).save(any(Member.class));
         }


### PR DESCRIPTION
## 📌 관련 이슈
-

## ✨ 작업 내용
> 이번 PR에서 변경된 핵심 내용을 요약해주세요.

- 회원 탈퇴 시 크루 가입 상태와 무관하게 무조건 `EXITED`로 처리되던 로직을 수정했습니다.
  - 가입 완료(`JOINED`) 상태였던 크루 → 기존과 동일하게 탈퇴(`EXITED`) 처리
  - 가입 신청(`REQUESTED`) 상태였던 크루 → 신청 취소(`CANCELLED`) 처리 (이미 존재하던 `CrewMember.cancel()` 재사용)
- 크루 멤버 조회를 이력 전체 조회(`findAllByMemberId`) 대신 활성 상태(`JOINED`/`REQUESTED`)만 걸러오는 기존 `findAllActiveByMemberId`로 변경하여, 이미 종결된 이력(`REJECTED`/`EXPELLED`/`CANCELLED`/`EXITED`)까지 불필요하게 조회·재저장하던 부분을 제거했습니다.
- `validateWithdrawal`과 `processCrewWithdrawal`이 각각 크루 멤버를 조회하던 것을 `withdraw`/`withdrawBySocialInfo`에서 한 번만 조회해 전달하도록 통합해 중복 쿼리를 없앴습니다.

## 🧱 아키텍처 변경 요약
> 이번 작업으로 인해 변경된 주요 흐름을 적어주세요. (없으면 생략 가능)

- `MemberService.validateWithdrawal`, `processCrewWithdrawal`의 시그니처가 `List<CrewMember>`를 파라미터로 받도록 변경 (내부 조회 로직을 호출부로 이동)

## 📸 스크린샷 (선택 사항)
> API 테스트 결과 등을 첨부해주세요.

## ⚠️ 주의 사항 (선택)
- [ ] DB 스키마 변경이 있나요?
- [ ] API 명세(Swagger)가 업데이트 되었나요?
- [ ] 새로운 환경 변수(.env)가 추가 되었나요?

## ✅ 셀프 체크리스트
- [ ] 브랜치 전략(develop)에 맞게 올렸나요?
- [ ] 커밋 컨벤션을 준수했나요?
- [ ] 불필요한 주석이나 print문은 제거했나요?
- [ ] 로컬에서 테스트는 성공했나요?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
